### PR TITLE
Hotfix vsum

### DIFF
--- a/libraries/vdifio/ChangeLog
+++ b/libraries/vdifio/ChangeLog
@@ -3,6 +3,7 @@ Version 1.6
 * Post DiFX-2.8
 * vdifbstate: add option to look at only even or odd samples
 * filterVDIF: fix fclose on null pointer
+* vdiffile: fix calculation for end time
 
 Version 1.5
 ~~~~~~~~~~~

--- a/libraries/vdifio/src/vdiffile.c
+++ b/libraries/vdifio/src/vdiffile.c
@@ -322,8 +322,7 @@ int summarizevdiffile(struct vdif_file_summary *sum, const char *fileName, int f
 			
 			if(getVDIFFrameBytes(vh) == frameSize &&
 			   getVDIFEpoch(vh) == sum->epoch &&
-			   getVDIFBitsPerSample(vh) == sum->nBit &&
-			   abs(s - getVDIFFrameEpochSecOffset(vh0)) < 2)
+			   getVDIFBitsPerSample(vh) == sum->nBit)
 			{
 				hasThread[getVDIFThreadID(vh)] = 1;
 				f = getVDIFFrameNumber(vh);


### PR DESCRIPTION
Minor fix here.  For files with low data rates the vsum end time isn't calculated properly.  Fix is tested to work.  Could someone add to main?