### PR TITLE
Feature difx2fits freq filtering

### DIFF
--- a/applications/difx2fits/ChangeLog
+++ b/applications/difx2fits/ChangeLog
@@ -18,6 +18,7 @@ Version 3.8.0
     - Derived total delays are _not_ invariant to this
 * Create a .channels file that lists the frequency set as a function of time.
 * Add option to only propagate a finite list of sources
+* Add option to only propagate sky frequencies provided in a list of low band edge frequencies
 
 Version 3.7.0
 * Post DiFX-2.6

--- a/applications/difx2fits/src/difx2fits.c
+++ b/applications/difx2fits/src/difx2fits.c
@@ -171,6 +171,8 @@ static void usage(const char *pgm)
 	fprintf(stderr, "                      Read <file> and apply it as delay corrections to the output\n");
 	fprintf(stderr, "  --sourcelist <list>\n");
 	fprintf(stderr, "                      Only propagate source(s) listed (comma separated)\n");
+	fprintf(stderr, "  --freqlist <list>\n");
+	fprintf(stderr, "                      Only propagate IFs with listed low edge freqs (comma separated, MHz)\n");
 	fprintf(stderr, "%s responds to the following environment variables:\n", program);
 	fprintf(stderr, "    DIFX_GROUP_ID             If set, run with umask(2).\n");
 	fprintf(stderr, "    DIFX_VERSION              The DiFX version to report.\n");
@@ -242,6 +244,11 @@ void deleteCommandLineOptions(struct CommandLineOptions *opts)
 		{
 			free(opts->includeSourceList);
 			opts->includeSourceList = 0;
+		}
+		if(opts->includeLowEdgeFreqsList)
+		{
+			free(opts->includeLowEdgeFreqsList);
+			opts->includeLowEdgeFreqsList = 0;
 		}
 		free(opts);
 	}
@@ -517,6 +524,31 @@ struct CommandLineOptions *parseCommandLine(int argc, char **argv)
 						{
 							opts->includeSourceList[j] = ' ';
 						}
+					}
+				}
+				else if(strcmp(argv[i], "--freqlist") == 0)
+				{
+					int j, n;
+					char* token;
+
+					++i;
+					for (n = 1, j = 0; argv[i][j]; ++j)
+					{
+						if (argv[i][j] == ',')
+						{
+							++n;
+						}
+					}
+
+					opts->includeLowEdgeFreqsList = (double*)calloc(n+1, sizeof(double));
+
+					j = 0;
+					token = strtok(argv[i], ",");
+					while (token && j<n)
+					{
+						opts->includeLowEdgeFreqsList[j] = atof(token);
+						token = strtok(NULL, ",");
+						++j;
 					}
 				}
 				else if(strcmp(argv[i], "--applybandpass") == 0)

--- a/applications/difx2fits/src/difx2fits.c
+++ b/applications/difx2fits/src/difx2fits.c
@@ -206,7 +206,7 @@ struct CommandLineOptions *newCommandLineOptions()
 	opts->allpcaltones       = DefaultAllPcalTones;
 
 	resetDifxMergeOptions(&opts->mergeOptions);
-	resetDifxDatafilterOptions(&opts->filterOptions);
+	resetDifxDataFilterOptions(&opts->filterOptions);
 
 	return opts;
 }
@@ -249,7 +249,7 @@ void deleteCommandLineOptions(struct CommandLineOptions *opts)
 			opts->includeSourceList = 0;
 		}
 
-		deleteDifxDatafilterOptions(&opts->filterOptions);
+		deleteDifxDataFilterOptions(&opts->filterOptions);
 
 		free(opts);
 	}

--- a/applications/difx2fits/src/difx2fits.c
+++ b/applications/difx2fits/src/difx2fits.c
@@ -205,6 +205,9 @@ struct CommandLineOptions *newCommandLineOptions()
 	opts->DifxPcalAvgSeconds = DefaultDifxPCalInterval;
 	opts->allpcaltones       = DefaultAllPcalTones;
 
+	resetDifxMergeOptions(&opts->mergeOptions);
+	resetDifxDatafilterOptions(&opts->filterOptions);
+
 	return opts;
 }
 
@@ -245,11 +248,9 @@ void deleteCommandLineOptions(struct CommandLineOptions *opts)
 			free(opts->includeSourceList);
 			opts->includeSourceList = 0;
 		}
-		if(opts->includeLowEdgeFreqsList)
-		{
-			free(opts->includeLowEdgeFreqsList);
-			opts->includeLowEdgeFreqsList = 0;
-		}
+
+		deleteDifxDatafilterOptions(&opts->filterOptions);
+
 		free(opts);
 	}
 }
@@ -540,13 +541,13 @@ struct CommandLineOptions *parseCommandLine(int argc, char **argv)
 						}
 					}
 
-					opts->includeLowEdgeFreqsList = (double*)calloc(n+1, sizeof(double));
+					opts->filterOptions.includeLowEdgeFreqsList = (double*)calloc(n+1, sizeof(double));
 
 					j = 0;
 					token = strtok(argv[i], ",");
 					while (token && j<n)
 					{
-						opts->includeLowEdgeFreqsList[j] = atof(token);
+						opts->filterOptions.includeLowEdgeFreqsList[j] = atof(token);
 						token = strtok(NULL, ",");
 						++j;
 					}
@@ -1118,7 +1119,7 @@ static DifxInput **loadDifxInputSet(const struct CommandLineOptions *opts)
 			relabelCircular(Dset[i]);
 		}
 
-		Dset[i] = updateDifxInput(Dset[i], &opts->mergeOptions);
+		Dset[i] = updateDifxInput(Dset[i], &opts->mergeOptions, &opts->filterOptions);
 
 		if(opts->specAvg)
 		{
@@ -1320,7 +1321,7 @@ static int convertFits(const struct CommandLineOptions *opts, DifxInput **Dset, 
 		printDifxInput(D);
 	}
 
-	D = updateDifxInput(D, &opts->mergeOptions);
+	D = updateDifxInput(D, &opts->mergeOptions, &opts->filterOptions);
 
 	if(!D)
 	{

--- a/applications/difx2fits/src/difx2fits.h
+++ b/applications/difx2fits/src/difx2fits.h
@@ -83,7 +83,7 @@ struct CommandLineOptions
 	int relabelCircular;	/* if != 0, then relabel all polarizations as R/L regardless of their actual values */
 	int doVanVleck;		/* if != 0, then correct for Van Vleck (quantization correction) */
 	DifxMergeOptions mergeOptions;
-	DifxDatafilterOptions filterOptions;
+	DifxDataFilterOptions filterOptions;
 };
 
 const DifxInput *DifxInput2FitsHeader(const DifxInput *D,

--- a/applications/difx2fits/src/difx2fits.h
+++ b/applications/difx2fits/src/difx2fits.h
@@ -46,6 +46,7 @@ struct CommandLineOptions
 	char *baseFile[MAX_INPUT_FILES];
 	char *applyBandpassFile;
 	char *includeSourceList;
+	double *includeLowEdgeFreqsList;
 	char *applyDelayCalFile;
 	int nBaseFile;
 	int writemodel;

--- a/applications/difx2fits/src/difx2fits.h
+++ b/applications/difx2fits/src/difx2fits.h
@@ -46,7 +46,6 @@ struct CommandLineOptions
 	char *baseFile[MAX_INPUT_FILES];
 	char *applyBandpassFile;
 	char *includeSourceList;
-	double *includeLowEdgeFreqsList;
 	char *applyDelayCalFile;
 	int nBaseFile;
 	int writemodel;
@@ -84,6 +83,7 @@ struct CommandLineOptions
 	int relabelCircular;	/* if != 0, then relabel all polarizations as R/L regardless of their actual values */
 	int doVanVleck;		/* if != 0, then correct for Van Vleck (quantization correction) */
 	DifxMergeOptions mergeOptions;
+	DifxDatafilterOptions filterOptions;
 };
 
 const DifxInput *DifxInput2FitsHeader(const DifxInput *D,

--- a/applications/difx2fits/src/fitsUV.c
+++ b/applications/difx2fits/src/fitsUV.c
@@ -827,9 +827,9 @@ int DifxVisNewUVData(DifxVis *dv, const struct CommandLineOptions *opts, const D
 	}
 
 	/* adjust freqId through remapping if needed */
-	if(dv->D->job[dv->jobId].freqIdRemap)
+	if(dv->D->job[dv->jobId].jobfreqIdRemap)
 	{
-		freqId = dv->D->job[dv->jobId].freqIdRemap[freqId];
+		freqId = dv->D->job[dv->jobId].jobfreqIdRemap[freqId];
 	}
 
 	/* if chan weights are written the data volume is 3/2 as large */
@@ -1449,31 +1449,6 @@ static int ExcludeSource(const DifxVis *dv, const int *includeSourceIdList)
 	return 1;	/* turf it -- it is not on the provided list */
 }
 
-/* includeLowEdgeFreqsList should be terminated with 0.0, or can be a null pointer */
-static int ExcludeIF(const DifxVis *dv, const double *includeLowEdgeFreqsList)
-{
-	if(includeLowEdgeFreqsList == 0)
-	{
-		/* No list provided, so no filtering */
-
-		return 0;
-	}
-	else
-	{
-//		printf("ExcludeIF() check DifxVis->freqId=%d\n", dv->freqId);
-//		int i;
-//
-//		for(i = 0; includeLowEdgeFreqsList[i] > 0; ++i)
-//		{
-//			// TODO: dv->freqId which is "DiFX FreqSetId or FITS freqId",
-//			//       how to look up the actual frequency of this DifxVis record?
-//		}
-		return 0;
-	}
-
-	return 1;	/* turf it -- it is not on the provided list */
-}
-
 const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fits_keys, struct fitsPrivate *out, const struct CommandLineOptions *opts, int passNum)
 {
 	int i, l, v;
@@ -1496,7 +1471,6 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 	int nWritten = 0;
 	int nOld = 0;
 	int nSourceFiltered = 0;	/* number of records discarded due to being on source exclusion list */
-	int nFreqsFiltered = 0;
 	int nSkipped = 0;
 	int nSkipped_recs;
 	double mjd, bestmjd;
@@ -1820,10 +1794,6 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 		{
 			++nSourceFiltered;
 		}
-		else if(ExcludeIF(dv, opts->includeLowEdgeFreqsList))
-		{
-			++nFreqsFiltered;
-		}
 		else
 		{
 #ifdef HAVE_FFTW
@@ -1900,7 +1870,6 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 	printf("      %d scan boundary records dropped\n", nTrans);
 	printf("      %d out-of-time-range records dropped\n", nOld);
 	printf("      %d records from excluded sources dropped\n", nSourceFiltered);
-	printf("      %d records from excluded IFs dropped\n", nFreqsFiltered);
 	printf("      %d records skipped\n", nSkipped);
 	printf("      %d records written\n", nWritten);
 	if(nWritten > 0)

--- a/applications/difx2fits/src/fitsUV.c
+++ b/applications/difx2fits/src/fitsUV.c
@@ -1449,6 +1449,31 @@ static int ExcludeSource(const DifxVis *dv, const int *includeSourceIdList)
 	return 1;	/* turf it -- it is not on the provided list */
 }
 
+/* includeLowEdgeFreqsList should be terminated with 0.0, or can be a null pointer */
+static int ExcludeIF(const DifxVis *dv, const double *includeLowEdgeFreqsList)
+{
+	if(includeLowEdgeFreqsList == 0)
+	{
+		/* No list provided, so no filtering */
+
+		return 0;
+	}
+	else
+	{
+//		printf("ExcludeIF() check DifxVis->freqId=%d\n", dv->freqId);
+//		int i;
+//
+//		for(i = 0; includeLowEdgeFreqsList[i] > 0; ++i)
+//		{
+//			// TODO: dv->freqId which is "DiFX FreqSetId or FITS freqId",
+//			//       how to look up the actual frequency of this DifxVis record?
+//		}
+		return 0;
+	}
+
+	return 1;	/* turf it -- it is not on the provided list */
+}
+
 const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fits_keys, struct fitsPrivate *out, const struct CommandLineOptions *opts, int passNum)
 {
 	int i, l, v;
@@ -1471,6 +1496,7 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 	int nWritten = 0;
 	int nOld = 0;
 	int nSourceFiltered = 0;	/* number of records discarded due to being on source exclusion list */
+	int nFreqsFiltered = 0;
 	int nSkipped = 0;
 	int nSkipped_recs;
 	double mjd, bestmjd;
@@ -1794,6 +1820,10 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 		{
 			++nSourceFiltered;
 		}
+		else if(ExcludeIF(dv, opts->includeLowEdgeFreqsList))
+		{
+			++nFreqsFiltered;
+		}
 		else
 		{
 #ifdef HAVE_FFTW
@@ -1870,6 +1900,7 @@ const DifxInput *DifxInput2FitsUV(const DifxInput *D, struct fits_keywords *p_fi
 	printf("      %d scan boundary records dropped\n", nTrans);
 	printf("      %d out-of-time-range records dropped\n", nOld);
 	printf("      %d records from excluded sources dropped\n", nSourceFiltered);
+	printf("      %d records from excluded IFs dropped\n", nFreqsFiltered);
 	printf("      %d records skipped\n", nSkipped);
 	printf("      %d records written\n", nWritten);
 	if(nWritten > 0)

--- a/applications/difx2mark4/src/difx2mark4.c
+++ b/applications/difx2mark4/src/difx2mark4.c
@@ -241,7 +241,7 @@ int convertMark4 (struct CommandLineOptions *opts, int *nScan, int *nScanTot)
     if(opts->verbose > 2)
         printDifxInput(D);
 
-    D = updateDifxInput(D, 0);
+    D = updateDifxInput(D, 0, 0);
 
     if(!D)
         {

--- a/applications/vex2difx/src/vex2difx.cpp
+++ b/applications/vex2difx/src/vex2difx.cpp
@@ -713,7 +713,7 @@ static void populateFreqTable(DifxInput *D, const vector<freq>& freqs, const vec
 	D->nFreq = freqs.size();
 	D->freq = newDifxFreqArray(D->nFreq);
 	D->nFreqUnsimplified = D->nFreq;
-	D->freqIdRemap = (int *)calloc(D->nFreqUnsimplified+1, sizeof(int));
+	D->freqIdRemap = newRemap(D->nFreqUnsimplified);
 
 	for(int f = 0; f < D->nFreq; ++f)
 	{

--- a/libraries/difxio/difxio/difx_input.c
+++ b/libraries/difxio/difxio/difx_input.c
@@ -441,7 +441,7 @@ int isMixedPolMask(const int polmask)
  * @param D DifxInput object
  * @return -1 in case of error, 0 otherwise
  */
-static int generateFreqSets(DifxInput *D, const DifxDatafilterOptions *filterOptions)
+static int generateFreqSets(DifxInput *D, const DifxDataFilterOptions *filterOptions)
 {
 	int configId;
 	int verbose;
@@ -1936,7 +1936,7 @@ static DifxInput *parseDifxInputNetworkTable(DifxInput *D,
         return D;
 }
 
-static DifxInput *deriveDifxInputValues(DifxInput *D, const DifxDatafilterOptions *filterOptions)
+static DifxInput *deriveDifxInputValues(DifxInput *D, const DifxDataFilterOptions *filterOptions)
 {
 	int c, v;
 	
@@ -3652,7 +3652,7 @@ static int mergeDifxInputFreqSets(DifxInput *D, const DifxMergeOptions *mergeOpt
 	return nError;
 }
 
-DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions, const DifxDatafilterOptions *filterOptions)
+DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions, const DifxDataFilterOptions *filterOptions)
 {
 	static const DifxMergeOptions defaultMergeOptions;      /* initialized to zeros */
 	int nError;
@@ -4868,15 +4868,15 @@ void resetDifxMergeOptions(DifxMergeOptions *mergeOptions)
 	}
 }
 
-void resetDifxDatafilterOptions(DifxDatafilterOptions *filterOptions)
+void resetDifxDataFilterOptions(DifxDataFilterOptions *filterOptions)
 {
 	if(filterOptions)
 	{
-		memset(filterOptions, 0, sizeof(DifxDatafilterOptions));
+		memset(filterOptions, 0, sizeof(DifxDataFilterOptions));
 	}
 }
 
-void deleteDifxDatafilterOptions(DifxDatafilterOptions *filterOptions)
+void deleteDifxDataFilterOptions(DifxDataFilterOptions *filterOptions)
 {
 	if(filterOptions)
 	{

--- a/libraries/difxio/difxio/difx_input.c
+++ b/libraries/difxio/difxio/difx_input.c
@@ -440,7 +440,7 @@ int isMixedPolMask(const int polmask)
  * @param D DifxInput object
  * @return -1 in case of error, 0 otherwise
  */
-static int generateFreqSets(DifxInput *D)
+static int generateFreqSets(DifxInput *D, const DifxDatafilterOptions *filterOptions)
 {
 	int configId;
 	int verbose;
@@ -1902,7 +1902,7 @@ static DifxInput *parseDifxInputNetworkTable(DifxInput *D,
         return D;
 }
 
-static DifxInput *deriveDifxInputValues(DifxInput *D)
+static DifxInput *deriveDifxInputValues(DifxInput *D, const DifxDatafilterOptions *filterOptions)
 {
 	int c, v;
 	
@@ -1956,7 +1956,7 @@ static DifxInput *deriveDifxInputValues(DifxInput *D)
 		D->config[c].quantBits = qb;
 	}
 
-	v = generateFreqSets(D);
+	v = generateFreqSets(D, filterOptions);
 	if(v < 0)
 	{
 		fprintf(stderr, "Fatal error generating freq sets for configId(s)\n");
@@ -3618,7 +3618,7 @@ static int mergeDifxInputFreqSets(DifxInput *D, const DifxMergeOptions *mergeOpt
 	return nError;
 }
 
-DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions)
+DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions, const DifxDatafilterOptions *filterOptions)
 {
 	static const DifxMergeOptions defaultMergeOptions;      /* initialized to zeros */
 	int nError;
@@ -3629,7 +3629,7 @@ DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions)
 		mergeOptions = &defaultMergeOptions;
 	}
 
-	D = deriveDifxInputValues(D);
+	D = deriveDifxInputValues(D, filterOptions);
 	if(D == NULL)
 	{
 		fprintf(stderr, "Merging Frequency Setups failed.  Could not derive input values.\n");
@@ -4828,6 +4828,43 @@ int DifxInputGetSourceId(const DifxInput *D, const char *sourceName)
 
 void resetDifxMergeOptions(DifxMergeOptions *mergeOptions)
 {
-	memset(mergeOptions, 0, sizeof(DifxMergeOptions));
+	if(mergeOptions)
+	{
+		memset(mergeOptions, 0, sizeof(DifxMergeOptions));
+	}
 }
 
+void resetDifxDatafilterOptions(DifxDatafilterOptions *filterOptions)
+{
+	if(filterOptions)
+	{
+		memset(filterOptions, 0, sizeof(DifxDatafilterOptions));
+	}
+}
+
+void deleteDifxDatafilterOptions(DifxDatafilterOptions *filterOptions)
+{
+	if(filterOptions)
+	{
+		if(filterOptions->includeAntennasList)
+		{
+			int i;
+			for (i = 0; filterOptions->includeAntennasList[i] != NULL; ++i)
+			{
+				free(filterOptions->includeAntennasList[i]);
+			}
+			free(filterOptions->includeAntennasList);
+			filterOptions->includeAntennasList = 0;
+		}
+		if(filterOptions->includeLowEdgeFreqsList)
+		{
+			free(filterOptions->includeLowEdgeFreqsList);
+			filterOptions->includeLowEdgeFreqsList = 0;
+		}
+		if(filterOptions->includeBandwidthsList)
+		{
+			free(filterOptions->includeBandwidthsList);
+			filterOptions->includeBandwidthsList = 0;
+		}
+	}
+}

--- a/libraries/difxio/difxio/difx_input.c
+++ b/libraries/difxio/difxio/difx_input.c
@@ -1904,7 +1904,7 @@ static DifxInput *parseDifxInputNetworkTable(DifxInput *D,
 
 static DifxInput *deriveDifxInputValues(DifxInput *D)
 {
-	int c;
+	int c, v;
 	
 	if(!D)
 	{
@@ -1956,17 +1956,12 @@ static DifxInput *deriveDifxInputValues(DifxInput *D)
 		D->config[c].quantBits = qb;
 	}
 
-	for(c = 0; c < D->nConfig; ++c)
+	v = generateFreqSets(D);
+	if(v < 0)
 	{
-		int v;
+		fprintf(stderr, "Fatal error generating freq sets for configId(s)\n");
 
-		v = generateFreqSets(D);
-		if(v < 0)
-		{
-			fprintf(stderr, "Fatal error processing configId %d\n", c);
-
-			return 0;
-		}
+		return 0;
 	}
 
 	return D;

--- a/libraries/difxio/difxio/difx_input.h
+++ b/libraries/difxio/difxio/difx_input.h
@@ -304,10 +304,10 @@ typedef struct
 typedef struct
 {
 	int verbose;
-	char **includeAntennasList; /* TODO; if not NULL, ignore all antennas not found in this NULL-terminated list (2-letter codes, case insensitive) */
+	char **includeAntennasList; /* TODO; if not NULL, ignore all antennas not found in this NULL-terminated list of DiFX antenna names */
 	double *includeLowEdgeFreqsList; /* if not NULL, produce DifxIF entries only for DifxFreq's whose low edge freq (in MHz) is found in this 0-terminated list */
 	double *includeBandwidthsList; /* TODO; if not NULL, produce DifxIF entries only for DifxFreq's whose bandwidth (in MHz) is found in this 0-terminated list */
-} DifxDatafilterOptions;
+} DifxDataFilterOptions;
 
 /* Straight from DiFX frequency table */
 typedef struct
@@ -1031,8 +1031,8 @@ DifxAntennaFlag *mergeDifxAntennaFlagArrays(const DifxAntennaFlag *df1, int ndf1
 
 /* DifxInput functions */
 void resetDifxMergeOptions(DifxMergeOptions *mergeOptions);
-void resetDifxDatafilterOptions(DifxDatafilterOptions *filterOptions);
-void deleteDifxDatafilterOptions(DifxDatafilterOptions *filterOptions);
+void resetDifxDataFilterOptions(DifxDataFilterOptions *filterOptions);
+void deleteDifxDataFilterOptions(DifxDataFilterOptions *filterOptions);
 enum ToneSelection stringToToneSelection(const char *str);
 DifxInput *newDifxInput();
 void deleteDifxInput(DifxInput *D);
@@ -1044,7 +1044,7 @@ void DifxConfigMapAntennas(DifxConfig *dc, const DifxDatastream *ds);
 DifxInput *loadDifxInput(const char *filePrefix);
 DifxInput *loadDifxCalc(const char *filePrefix);
 DifxInput *allocateSourceTable(DifxInput *D, int length);
-DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions, const DifxDatafilterOptions *filterOptions);
+DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions, const DifxDataFilterOptions *filterOptions);
 int areDifxInputsCompatible(const DifxInput *D1, const DifxInput *D2, const DifxMergeOptions *mergeOptions);
 DifxInput *mergeDifxInputs(const DifxInput *D1, const DifxInput *D2, const DifxMergeOptions *mergeOptions);
 int isAntennaFlagged(const DifxJob *J, double mjd, int antennaId);

--- a/libraries/difxio/difxio/difx_input.h
+++ b/libraries/difxio/difxio/difx_input.h
@@ -300,6 +300,15 @@ typedef struct
 	enum ClockMergeMode clockMergeMode;
 } DifxMergeOptions;
 
+/* structure containing options that affect data filtering */
+typedef struct
+{
+	int verbose;
+	char **includeAntennasList; /* TODO; if not NULL, ignore all antennas not found in this NULL-terminated list (2-letter codes, case insensitive) */
+	double *includeLowEdgeFreqsList; /* if not NULL, produce DifxIF entries only for DifxFreq's whose low edge freq (in MHz) is found in this 0-terminated list */
+	double *includeBandwidthsList; /* TODO; if not NULL, produce DifxIF entries only for DifxFreq's whose bandwidth (in MHz) is found in this 0-terminated list */
+} DifxDatafilterOptions;
+
 /* Straight from DiFX frequency table */
 typedef struct
 {
@@ -677,7 +686,7 @@ typedef struct
 
 	/* Remappings.  These are null arrays unless some renumbering from original values occurred */
 	int *jobIdRemap;	/* confusingly, not the same jobId as that in this structure, but rather index to DifxJob */
-	int *freqIdRemap;
+	int *jobfreqIdRemap;
 	int *antennaIdRemap;
 	int *datastreamIdRemap;
 	int *baselineIdRemap;
@@ -1022,6 +1031,8 @@ DifxAntennaFlag *mergeDifxAntennaFlagArrays(const DifxAntennaFlag *df1, int ndf1
 
 /* DifxInput functions */
 void resetDifxMergeOptions(DifxMergeOptions *mergeOptions);
+void resetDifxDatafilterOptions(DifxDatafilterOptions *filterOptions);
+void deleteDifxDatafilterOptions(DifxDatafilterOptions *filterOptions);
 enum ToneSelection stringToToneSelection(const char *str);
 DifxInput *newDifxInput();
 void deleteDifxInput(DifxInput *D);
@@ -1033,7 +1044,7 @@ void DifxConfigMapAntennas(DifxConfig *dc, const DifxDatastream *ds);
 DifxInput *loadDifxInput(const char *filePrefix);
 DifxInput *loadDifxCalc(const char *filePrefix);
 DifxInput *allocateSourceTable(DifxInput *D, int length);
-DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions);
+DifxInput *updateDifxInput(DifxInput *D, const DifxMergeOptions *mergeOptions, const DifxDatafilterOptions *filterOptions);
 int areDifxInputsCompatible(const DifxInput *D1, const DifxInput *D2, const DifxMergeOptions *mergeOptions);
 DifxInput *mergeDifxInputs(const DifxInput *D1, const DifxInput *D2, const DifxMergeOptions *mergeOptions);
 int isAntennaFlagged(const DifxJob *J, double mjd, int antennaId);

--- a/libraries/difxio/difxio/difx_input_merge.c
+++ b/libraries/difxio/difxio/difx_input_merge.c
@@ -238,7 +238,7 @@ DifxInput *mergeDifxInputs(const DifxInput *D1, const DifxInput *D2, const DifxM
 	DifxInput *D;
 	DifxJob *job;
 	int *jobIdRemap;
-	int *freqIdRemap;
+	int *jobfreqIdRemap;
 	int *antennaIdRemap;
 	int *datastreamIdRemap;
 	int *baselineIdRemap;
@@ -260,7 +260,7 @@ DifxInput *mergeDifxInputs(const DifxInput *D1, const DifxInput *D2, const DifxM
 
 	/* allocate some scratch space */
 	jobIdRemap        = newRemap(D2->nJob);
-	freqIdRemap       = newRemap(D2->nFreq);
+	jobfreqIdRemap    = newRemap(D2->nFreq);
 	antennaIdRemap    = newRemap(D2->nAntenna);
 	datastreamIdRemap = newRemap(D2->nDatastream);
 	baselineIdRemap   = newRemap(D2->nBaseline);
@@ -328,18 +328,18 @@ DifxInput *mergeDifxInputs(const DifxInput *D1, const DifxInput *D2, const DifxM
 
 	/* merge DifxFreq table */
 	D->freq = mergeDifxFreqArrays(D1->freq, D1->nFreq,
-		D2->freq, D2->nFreq, freqIdRemap, &(D->nFreq), D->AllPcalTones);
+		D2->freq, D2->nFreq, jobfreqIdRemap, &(D->nFreq), D->AllPcalTones);
 
 	/* merge DifxDatastream table */
 	D->datastream = mergeDifxDatastreamArrays(D1->datastream, 
 		D1->nDatastream, D2->datastream, D2->nDatastream,
-		datastreamIdRemap, freqIdRemap, antennaIdRemap,
+		datastreamIdRemap, jobfreqIdRemap, antennaIdRemap,
 		&(D->nDatastream));
 
 	/* merge DifxBaseline table */
 	D->baseline = mergeDifxBaselineArrays(D1->baseline, D1->nBaseline,
 		D2->baseline, D2->nBaseline, baselineIdRemap,
-		datastreamIdRemap, freqIdRemap, &(D->nBaseline));
+		datastreamIdRemap, jobfreqIdRemap, &(D->nBaseline));
 
 	/* merge DifxPulsar table */
 	D->pulsar = mergeDifxPulsarArrays(D1->pulsar, D1->nPulsar,
@@ -381,7 +381,7 @@ DifxInput *mergeDifxInputs(const DifxInput *D1, const DifxInput *D2, const DifxM
 	/* store the remappings of the added job in case it is useful later */
 	job = D->job + D1->nJob;	/* points to first (probably only) job from D2 */
 	job->jobIdRemap = jobIdRemap;
-	job->freqIdRemap = freqIdRemap;
+	job->jobfreqIdRemap = jobfreqIdRemap;
 	job->antennaIdRemap = antennaIdRemap;
 	job->datastreamIdRemap = datastreamIdRemap;
 	job->baselineIdRemap = baselineIdRemap;

--- a/libraries/difxio/difxio/difx_job.c
+++ b/libraries/difxio/difxio/difx_job.c
@@ -116,8 +116,8 @@ void deleteDifxJobArray(DifxJob *djarray, int nJob)
 		dj->flag = 0;
 		deleteRemap(dj->jobIdRemap);
 		dj->jobIdRemap = 0;
-		deleteRemap(dj->freqIdRemap);
-		dj->freqIdRemap = 0;
+		deleteRemap(dj->jobfreqIdRemap);
+		dj->jobfreqIdRemap = 0;
 		deleteRemap(dj->antennaIdRemap);
 		dj->antennaIdRemap = 0;
 		deleteRemap(dj->datastreamIdRemap);
@@ -155,7 +155,7 @@ void fprintDifxJob(FILE *fp, const DifxJob *dj)
 	fprintf(fp, "    flag file = %s\n", dj->flagFile);
 	fprintf(fp, "    output file = %s\n", dj->outputFile);
 	fprintRemap(fp, "  jobId", dj->jobIdRemap);
-	fprintRemap(fp, "  freqId", dj->freqIdRemap);
+	fprintRemap(fp, "  jobfreqId", dj->jobfreqIdRemap);
 	fprintRemap(fp, "  antennaId", dj->antennaIdRemap);
 	fprintRemap(fp, "  datastreamId", dj->datastreamIdRemap);
 	fprintRemap(fp, "  baselineId", dj->baselineIdRemap);
@@ -195,7 +195,7 @@ void copyDifxJob(DifxJob *dest, const DifxJob *src, int *antennaIdRemap)
 		}
 
 		dest->jobIdRemap = dupRemap(src->jobIdRemap);
-		dest->freqIdRemap = dupRemap(src->freqIdRemap);
+		dest->jobfreqIdRemap = dupRemap(src->jobfreqIdRemap);
 		dest->antennaIdRemap = dupRemap(src->antennaIdRemap);
 		dest->datastreamIdRemap = dupRemap(src->datastreamIdRemap);
 		dest->baselineIdRemap = dupRemap(src->baselineIdRemap);
@@ -287,10 +287,10 @@ void DifxJobQuashTrivialRemaps(DifxJob *dj)
 		deleteRemap(dj->jobIdRemap);
 		dj->jobIdRemap = 0;
 	}
-	if(isRemapTrivial(dj->freqIdRemap))
+	if(isRemapTrivial(dj->jobfreqIdRemap))
 	{
-		deleteRemap(dj->freqIdRemap);
-		dj->freqIdRemap = 0;
+		deleteRemap(dj->jobfreqIdRemap);
+		dj->jobfreqIdRemap = 0;
 	}
 	if(isRemapTrivial(dj->antennaIdRemap))
 	{

--- a/libraries/difxio/tests/testdifxinput.c
+++ b/libraries/difxio/tests/testdifxinput.c
@@ -167,7 +167,7 @@ int main(int argc, char **argv)
 		return EXIT_SUCCESS;
 	}
 
-	D = updateDifxInput(D, &mergeOptions);
+	D = updateDifxInput(D, &mergeOptions, 0);
 	if(!D)
 	{
 		fprintf(stderr, "Update failed: D == 0.  Quitting\n");

--- a/libraries/difxio/utils/avgDiFX.c
+++ b/libraries/difxio/utils/avgDiFX.c
@@ -298,7 +298,7 @@ AverageInput *openAverageInput(const char *filename)
 
 		return 0;
 	}
-	A->D = updateDifxInput(A->D, 0);
+	A->D = updateDifxInput(A->D, 0, 0);
 	if(!A->D)
 	{
 		fprintf(stderr, "Update failed for DiFX fileset %s.  Quitting\n", filename);

--- a/libraries/difxio/utils/calcderiv.c
+++ b/libraries/difxio/utils/calcderiv.c
@@ -120,7 +120,7 @@ int computeLMDerivatives(DifxInput *D, double deltaLM, const char *calcProgram, 
 			
 			return -1;
 		}
-		DD[i] = updateDifxInput(DD[i], 0);
+		DD[i] = updateDifxInput(DD[i], 0, 0);
 		if(!DD[i])
 		{
 			fprintf(stderr, "Update failed for fileset %s number %d\n", D->job->inputFile, i);
@@ -266,7 +266,7 @@ int computeXYZDerivatives(DifxInput *D, double deltaXYZ, const char *calcProgram
 			
 			return -1;
 		}
-		DD[i] = updateDifxInput(DD[i], 0);
+		DD[i] = updateDifxInput(DD[i], 0, 0);
 		if(!DD[i])
 		{
 			fprintf(stderr, "Update failed for fileset %s number %d\n", D->job->inputFile, i);
@@ -386,7 +386,7 @@ int run(const char *fileBase, int verbose, double deltaLM, double deltaXYZ)
 		
 		return -1;
 	}
-	D = updateDifxInput(D, 0);
+	D = updateDifxInput(D, 0, 0);
 	if(!D)
 	{
 		fprintf(stderr, "Update failed for fileset named %s: D == 0.  Quitting\n", fileBase);

--- a/libraries/difxio/utils/computetotals.c
+++ b/libraries/difxio/utils/computetotals.c
@@ -130,7 +130,7 @@ int main(int argc, char **argv)
 		return EXIT_SUCCESS;
 	}
 
-	D = updateDifxInput(D, 0);
+	D = updateDifxInput(D, 0, 0);
 	if(!D)
 	{
 		fprintf(stderr, "Update failed: D == 0.  Quitting\n");

--- a/libraries/difxio/utils/difxcalculator.c
+++ b/libraries/difxio/utils/difxcalculator.c
@@ -84,7 +84,7 @@ int main(int argc, char **argv)
 		return EXIT_FAILURE;
 	}
 
-	D = updateDifxInput(D, 0);
+	D = updateDifxInput(D, 0, 0);
 	if(!D)
 	{
 		fprintf(stderr, "update failed: D == 0.  quitting\n");

--- a/libraries/difxio/utils/difxfilelist.c
+++ b/libraries/difxio/utils/difxfilelist.c
@@ -80,7 +80,7 @@ int processInputFile(const char *filebase)
 		return -1;
 	}
 
-	D = updateDifxInput(D, 0);
+	D = updateDifxInput(D, 0, 0);
 	if(!D)
 	{
 		fprintf(stderr, "Error: updateDifxInput failed for DiFX fileset %s\n", filebase);

--- a/libraries/difxio/utils/psrflag.c
+++ b/libraries/difxio/utils/psrflag.c
@@ -499,7 +499,7 @@ int main(int argc, char **argv)
 		return EXIT_SUCCESS;
 	}
 
-	D = updateDifxInput(D, 0);
+	D = updateDifxInput(D, 0, 0);
 	if(!D)
 	{
 		fprintf(stderr, "Update failed: D == 0.  Quitting\n");

--- a/libraries/difxio/utils/reducepoly.c
+++ b/libraries/difxio/utils/reducepoly.c
@@ -390,7 +390,7 @@ int main(int argc, char **argv)
 			DifxInput *D;
 			
 			D = loadDifxInput(argv[a]);
-			D = updateDifxInput(D, 0);
+			D = updateDifxInput(D, 0, 0);
 			if(!D)
 			{
 				fprintf(stderr, "Update failed: D == 0.  Quitting\n");

--- a/libraries/difxio/utils/tabulatedelays.c
+++ b/libraries/difxio/utils/tabulatedelays.c
@@ -371,7 +371,7 @@ int main(int argc, char **argv)
 		return EXIT_SUCCESS;
 	}
 
-	D = updateDifxInput(D, 0);
+	D = updateDifxInput(D, 0, 0);
 	if(!D)
 	{
 		fprintf(stderr, "Update failed: D == 0.  Quitting.\n");

--- a/utilities/calcif2/src/calcif2.c
+++ b/utilities/calcif2/src/calcif2.c
@@ -573,7 +573,7 @@ static int runfile(const char *prefix, const CommandLineOptions *opts, CalcParam
 		return -1;
 	}
 
-	D = updateDifxInput(D, 0);
+	D = updateDifxInput(D, 0, 0);
 	if(D == 0)
 	{
 		fprintf(stderr, "Error: updateDifxInput(\"%s\") returned 0\n", prefix);

--- a/utilities/calcif2/src/difxvmf.c
+++ b/utilities/calcif2/src/difxvmf.c
@@ -114,7 +114,7 @@ int processFile(const char *inputFile, const DifxMergeOptions *mergeOptions, con
 		printf("Warning: calcif2: working on unversioned job\n");
 	}
 
-	D = updateDifxInput(D, mergeOptions);
+	D = updateDifxInput(D, mergeOptions, 0);
 	if(!D)
 	{
 		fprintf(stderr, "Error: %s updateDifxInput(): update of %s failed.\n", program, inputFile);

--- a/utilities/vdifsim/src/sim.c
+++ b/utilities/vdifsim/src/sim.c
@@ -306,7 +306,7 @@ int simulate(const CommandLineOptions *opts)
 
 			break;
 		}
-		D = updateDifxInput(D, 0);
+		D = updateDifxInput(D, 0, 0);
 		if(!D)
 		{
 			fprintf(stderr, "Rank %d : update failed: D == 0.\n", mpiRank);


### PR DESCRIPTION
Hi Walter, could you have a look at these changes?

They add a command line option to difx2fits,

$ difx2fits --help
  --freqlist <list>
                      Only propagate IFs with listed low edge freqs (comma separated, MHz)

With that, one can trim down the set of frequencies (& visibility records) that are going exported into the FITS-IDI file.

A usage example would be:

$ difx2fits -d -v -v -v --freqlist 86012,86076,86140,86204,86268,86332,86396,86460  example.fits

The above is for a test case in Bonn. DiFX correlation produced 64 MHz wide bands at sixteen sky frequencies 86012, 86076, 86140, 86204, 86268, 86332, 86396, 86460, 86524, 86588, 86652, 86716, 86780, 86844, 86908 MHz (low edges).

In a subset of the VLBI array only the first eight frequencies contain desired visibility data. 

Those data can now be exported in isolation using the new --freqlist option.

The resulting FITS-IDI has a clean frequency table without "errant" IF entries that'd lack visibility data. Such IFs in the frequency table but without data causes major issues in CASA, one project PI reported...


