### PR TITLE
Feature difx2mark4 outputbands with amplitude scaling fix

### DIFF
--- a/applications/difx2mark4/ChangeLog
+++ b/applications/difx2mark4/ChangeLog
@@ -2,6 +2,12 @@ Version 1.7
 ~~~~~~~~~~~
 * rjc 2020.6.26
 * fix parallactic angle bug in first t303 record
+* improved frequency table bookkeeping, avoiding duplicates, registering outputbands
+* fixed bug in '-w <bandwidth MHz>' that dropped all zooms at edges of parent bands
+* re-fixed issue of '-d' (or *.input) not working due to ignored DiFX antenna Id remap
+* fixed a normalization issue where autocorrelations were not looked up by their
+  actual DiFX freq IDs, stemming from vex2difx behaviour that creates own freq IDs for
+  every station that has a differing PCal spacing
 * Version for DiFX-2.8, Nov 4, 2022
 
 Version 1.6

--- a/applications/difx2mark4/src/createType1s.c
+++ b/applications/difx2mark4/src/createType1s.c
@@ -190,7 +190,7 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
             nvr = -1;               // set index just prior to first record in buffer
                                     // unless raw mode requested, normalize visibilities
             if (opts->raw == 0)
-                normalize (opts, vrec, nvrtot, nvis, vrsize, pfb);
+                normalize (D, opts, vrec, nvrtot, nvis, vrsize, pfb);
             rec = vrec;
             }
 

--- a/applications/difx2mark4/src/createType1s.c
+++ b/applications/difx2mark4/src/createType1s.c
@@ -338,7 +338,8 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
             strncpy (u.t120.baseline, blines+2*n, 2);
                                     // FIXME (perhaps) -assumes all freqs have same PolProds as 0
                                     // insert index# for this channel
-            u.t120.index = 10 * rec->freq_index + 1;
+            //u.t120.index = 10 * rec->freq_index + 1;
+            u.t120.index = 10 * pfb[vrmeta[nvr].pfbindex].stn[0].fmk4 + 1;
                                     // tack on offset that represents polarization
             for (i=0; i<4; i++)     
                 if (strncmp (poltabc[i],  rec->pols, 2) == 0
@@ -353,7 +354,8 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
             else
                 u.t120.fw.weight = rec->weight;
                                     // double-check that vis record pols match DiFX .input metadata
-            if (0) {
+            if (0)
+                {
                 char allowedpols[500];
                 int ff,pp, legal=0;
                                     // TODO: 'blind' from getBaselineIndex (D, a1, a2) futher above works only if both
@@ -384,7 +386,7 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
                     fprintf(stderr,
                             "Warning: mismatch on baseline %d (%.2s-%.2s) freq %d vis data has pol %.2s, .input has %s\n",
                             rec->baseline, (stns + a1)->intl_name, (stns + a2)->intl_name, rec->freq_index, rec->pols, allowedpols);
-            }
+                }
             u.t120.nlags = vrmeta[nvr].nvis;
                                     // calculate accumulation period index from start of scan
             u.t120.ap = (8.64e4 * (rec->mjd - D->scan[scanId].mjdStart) + rec->iat)

--- a/applications/difx2mark4/src/createType1s.c
+++ b/applications/difx2mark4/src/createType1s.c
@@ -68,9 +68,9 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
     static char corrdate[16];
     static int nvr = NOVIS,         // index of current visibility record
                nvrtot,              // total number of visibility records in buffer
-               nvis[NVRMAX],        // array of #visibilities for each record
-               vrsize[NVRMAX],      // array of visibility record sizes (bytes)
                currentScan;
+    static vis_record_meta
+               vrmeta[NVRMAX];      // array of vis. record metadata; #visibilities, record size, PFB index
     static vis_record *rec,
                       *vrec;
     
@@ -175,7 +175,7 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
             strcat (inname, dent->d_name);
             closedir (pdir);
                                     // open and read a complete Swinburne file
-            gv_stat = get_vis (D, inname, opts, &nvrtot, nvis, vrsize, &vrec, corrdate, pfb,
+            gv_stat = get_vis (D, inname, opts, &nvrtot, vrmeta, &vrec, corrdate, pfb,
                                (D->job+*jobId)->antennaIdRemap ? (D->job+*jobId)->antennaIdRemap : noRemap );
             if (gv_stat < -1)       // -1 is normal (EOF); anything less is an error
                 {
@@ -190,7 +190,7 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
             nvr = -1;               // set index just prior to first record in buffer
                                     // unless raw mode requested, normalize visibilities
             if (opts->raw == 0)
-                normalize (D, opts, vrec, nvrtot, nvis, vrsize, pfb);
+                normalize (D, opts, vrmeta, vrec, nvrtot, pfb);
             rec = vrec;
             }
 
@@ -209,7 +209,7 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
                 }
                                     // form pointer to current vis. record
             if (nvr > 0)
-                rec = (vis_record *) ((char *) rec + vrsize[nvr-1]);
+                rec = (vis_record *) ((char *) rec + vrmeta[nvr-1].vrsize);
                                     // check for new scan
             oldScan = currentScan;
             currentScan = DifxInputGetScanIdByJobId (D, rec->mjd+rec->iat/8.64e4-epsilon, *jobId);
@@ -287,7 +287,7 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
                         blind = 0;      // use first one in list and muster on
                         }
                     rc = new_type1 (D, pfb, n, a1, a2, blind, base_index, scale_factor, stns,
-                                    blines, opts, fout, nvis[nvr], rootname, node, rcode, 
+                                    blines, opts, fout, vrmeta[nvr].nvis, rootname, node, rcode, 
                                     corrdate, rec->baseline, scanId);
                     if (rc < 0)
                         return (rc);
@@ -305,7 +305,7 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
                 continue;           // to next record 
 
                                     // copy visibilities into type 120 record
-            for (i=0; i<nvis[nvr]; i++)
+            for (i=0; i<vrmeta[nvr].nvis; i++)
                 {                   
                 rscaled = rec->comp[i].real;
                 iscaled = rec->comp[i].imag;
@@ -331,8 +331,8 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
                     }
                 else                // reverse order of points in LSB spectrum
                     {               // and conjugate for rotator direction difference
-                    u.t120.ld.spec[nvis[nvr]-i-1].re =  rscaled;
-                    u.t120.ld.spec[nvis[nvr]-i-1].im = -iscaled;
+                    u.t120.ld.spec[vrmeta[nvr].nvis-i-1].re =  rscaled;
+                    u.t120.ld.spec[vrmeta[nvr].nvis-i-1].im = -iscaled;
                     }
                 }
             strncpy (u.t120.baseline, blines+2*n, 2);
@@ -385,7 +385,7 @@ int createType1s (DifxInput *D,     // ptr to a filled-out difx input structure
                             "Warning: mismatch on baseline %d (%.2s-%.2s) freq %d vis data has pol %.2s, .input has %s\n",
                             rec->baseline, (stns + a1)->intl_name, (stns + a2)->intl_name, rec->freq_index, rec->pols, allowedpols);
             }
-            u.t120.nlags = nvis[nvr];
+            u.t120.nlags = vrmeta[nvr].nvis;
                                     // calculate accumulation period index from start of scan
             u.t120.ap = (8.64e4 * (rec->mjd - D->scan[scanId].mjdStart) + rec->iat)
                                  / D->config[configId].tInt;

--- a/applications/difx2mark4/src/difx2mark4.h
+++ b/applications/difx2mark4/src/difx2mark4.h
@@ -34,6 +34,11 @@
 #define MAX_DFRQ 800                // allowed max number of *DiFX* frequencies
 #define NVRMAX 8000000              // max # of vis records
 
+// Type 309 records - limits for createType3s.c and write_t3??.c
+#define NPC_TONES 64                // max number of pcal tones in t309 record
+#define NPC_FREQS 64                // max number of channels (subset of DiFX freq IDs) in t309 record
+#define MAX_DS_RECBANDS 64          // max number of recorded bands in a datastream; FIXME: use dynamic allocation like in difxio/vex2difx and mpifxcorr
+
 enum booleans {FALSE, TRUE};
 
 struct CommandLineOptions

--- a/applications/difx2mark4/src/difx2mark4.h
+++ b/applications/difx2mark4/src/difx2mark4.h
@@ -112,7 +112,8 @@ struct fblock_tag
         char sideband;              // U or L
         char pol;                   // R or L
         int ant;                    // antenna table index
-        int find;                   // frequency table index
+        int find;                   // frequency table index of recorded/zoom band
+        int fdest;                  // frequency table index of destination freq that -"- contributes to
         int bs;                     // quantization bits/sample
         int first_time;             // true iff first entry in table of chan_id for ant 
         int zoom;                   // true iff this channel is zoom mode
@@ -157,7 +158,7 @@ int new_type1 (DifxInput *, struct fblock_tag *, int, int, int, int, int *, doub
                                     // write_t120.c
 void write_t120 (struct type_120 *, FILE *);
                                     // normalize.c
-void normalize (struct CommandLineOptions *, vis_record *, int, int *, int *, 
+void normalize (const DifxInput *, struct CommandLineOptions *, vis_record *, int, int *, int *, 
                 struct fblock_tag *);
                                     // root_id.c
 char *root_id(int, int, int, int, int);

--- a/applications/difx2mark4/src/difx2mark4.h
+++ b/applications/difx2mark4/src/difx2mark4.h
@@ -25,7 +25,7 @@
 
 #define MAX_INPUT_FILES 4096
 #define MAX_VIS 8192
-#define MAX_STN 50
+#define MAX_STN 64
 #define MAX_FBANDS 20 
 #define EXP_CODE_LEN 4
 #define NUMFILS 500                 // max number of type 1 output files
@@ -88,6 +88,13 @@ typedef struct
         } comp[MAX_VIS];
     } vis_record;
 
+typedef struct 
+    {
+    int nvis;                      // number of visibility spectral channels; vis_record::comp[0..nvis-1]
+    int vrsize;                    // size of the entire visibility record in bytes
+    int pfbindex;                  // index of matching PFB fblock_tag[] entry
+    } vis_record_meta;
+
 struct stations
     {
     int inscan;                     // in scan according to vex SCHED block
@@ -149,7 +156,7 @@ int createType1s (DifxInput *, struct fblock_tag *, int *, int, char *, char *,
 int createType3s (DifxInput *, struct fblock_tag *, int, int, int, char *, char *, 
                   struct stations *, struct CommandLineOptions *);
                                     // get_vis.c
-int get_vis (DifxInput *, char *, struct CommandLineOptions *, int *, int *, int *, 
+int get_vis (DifxInput *, char *, struct CommandLineOptions *, int *, vis_record_meta *, 
                  vis_record **, char *, struct fblock_tag *, int *);
                                     // new_type1.c
 int new_type1 (DifxInput *, struct fblock_tag *, int, int, int, int, int *, double *,
@@ -158,8 +165,8 @@ int new_type1 (DifxInput *, struct fblock_tag *, int, int, int, int, int *, doub
                                     // write_t120.c
 void write_t120 (struct type_120 *, FILE *);
                                     // normalize.c
-void normalize (const DifxInput *, struct CommandLineOptions *, vis_record *, int, int *, int *, 
-                struct fblock_tag *);
+void normalize (const DifxInput *, struct CommandLineOptions *, vis_record_meta *,
+                vis_record *, int, struct fblock_tag *);
                                     // root_id.c
 char *root_id(int, int, int, int, int);
 char *root_id_break(time_t, int, int, int, int, int);

--- a/applications/difx2mark4/src/difx2mark4.h
+++ b/applications/difx2mark4/src/difx2mark4.h
@@ -132,6 +132,12 @@ struct fblock_tag
         } stn[2];                   // reference | remote
     };
 
+typedef struct
+    {
+        double freq;                // LO frequency (MHz); negative for LSB
+        char sideband;              // U or L
+    } fblock_tag_lite;
+
 #include "type_000.h"
 #include "type_100.h"
 #include "type_101.h"

--- a/applications/difx2mark4/src/difx2mark4.h
+++ b/applications/difx2mark4/src/difx2mark4.h
@@ -121,6 +121,7 @@ struct fblock_tag
         int ant;                    // antenna table index
         int find;                   // frequency table index of recorded/zoom band
         int fdest;                  // frequency table index of destination freq that -"- contributes to
+        int fmk4;                   // index into mk4-only simplified freq list agnostic of USB/LSB and PCal spacing differences
         int bs;                     // quantization bits/sample
         int first_time;             // true iff first entry in table of chan_id for ant 
         int zoom;                   // true iff this channel is zoom mode

--- a/applications/difx2mark4/src/fill_fblock.c
+++ b/applications/difx2mark4/src/fill_fblock.c
@@ -357,27 +357,27 @@ static int fblock_already_exists(const struct fblock_tag *entries, int nentries,
 
     for (n=0; n<nentries; n++)
         {
-            int match[2] = {0,0};
-            for (k=0; k<2; k++)     // k = 0|1 for ref|rem antenna
-                {
-                if (entries[n].stn[k].pol      == candidate->stn[k].pol  &&
-                    entries[n].stn[k].ant      == candidate->stn[k].ant  &&
-                    entries[n].stn[k].find     == candidate->stn[k].find &&
-                    entries[n].stn[k].fdest    == candidate->stn[k].fdest    &&
-                    entries[n].stn[k].freq     == candidate->stn[k].freq     &&
-                    entries[n].stn[k].sideband == candidate->stn[k].sideband &&
-                    entries[n].stn[k].bw       == candidate->stn[k].bw       &&
-                    entries[n].stn[k].bs       == candidate->stn[k].bs       &&
-                    entries[n].stn[k].zoom     == candidate->stn[k].zoom     &&
-                    entries[n].stn[k].pcal_int == candidate->stn[k].pcal_int)
-                        {
-                        match[k] = 1;
-                        }
-                }
-            if (match[0] && match[1])
-                {
-                return 1;
-                }
+        int match[2] = {0,0};
+        for (k=0; k<2; k++)     // k = 0|1 for ref|rem antenna
+            {
+            if (entries[n].stn[k].pol      == candidate->stn[k].pol  &&
+                entries[n].stn[k].ant      == candidate->stn[k].ant  &&
+                entries[n].stn[k].find     == candidate->stn[k].find &&
+                entries[n].stn[k].fdest    == candidate->stn[k].fdest    &&
+                entries[n].stn[k].freq     == candidate->stn[k].freq     &&
+                entries[n].stn[k].sideband == candidate->stn[k].sideband &&
+                entries[n].stn[k].bw       == candidate->stn[k].bw       &&
+                entries[n].stn[k].bs       == candidate->stn[k].bs       &&
+                entries[n].stn[k].zoom     == candidate->stn[k].zoom     &&
+                entries[n].stn[k].pcal_int == candidate->stn[k].pcal_int)
+                    {
+                    match[k] = 1;
+                    }
+            }
+        if (match[0] && match[1])
+            {
+            return 1;
+            }
         }
 
     return 0;

--- a/applications/difx2mark4/src/fill_fblock.c
+++ b/applications/difx2mark4/src/fill_fblock.c
@@ -114,10 +114,6 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                     pfrB = D->freq + irfBfid;
                     }
 
-                                    // sanity check
-                assert(!pfb[nprod].stn[0].zoom || (pfb[nprod].stn[0].zoom && pfb[nprod].stn[0].sideband == 'U'));
-                assert(!pfb[nprod].stn[1].zoom || (pfb[nprod].stn[1].zoom && pfb[nprod].stn[1].sideband == 'U'));
-
                                     // info of output band
                 pfb[nprod].stn[0].pol      = polA;
                 pfb[nprod].stn[0].ant      = pdsA->antennaId;
@@ -143,6 +139,10 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                 pfb[nprod].stn[1].zoom     = zoomB;
                 pfb[nprod].stn[1].pcal_int = pdsB->phaseCalIntervalMHz / pdsB->phaseCalIntervalDivisor;
                 pfb[nprod].stn[1].n_spec_chan = pfrAB->nChan / pfrAB->specAvg;
+
+                                    // sanity check
+                assert(!pfb[nprod].stn[0].zoom || (pfb[nprod].stn[0].zoom && pfb[nprod].stn[0].sideband == 'U'));
+                assert(!pfb[nprod].stn[1].zoom || (pfb[nprod].stn[1].zoom && pfb[nprod].stn[1].sideband == 'U'));
 
                                 // store info of the destination product i.e. output band, if new,
                                 // and if not itself already covered by the source product stored higher above

--- a/applications/difx2mark4/src/fill_fblock.c
+++ b/applications/difx2mark4/src/fill_fblock.c
@@ -311,11 +311,11 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
         }
                                     // if desired bandwidth specified, 
                                     // remove any non-matching lines
-    if (strlen (opts->bandwidth) != 0)
+    if (filteredbw > 0)
         {
         nbw = 0;
         for (n=0; n<nprod; n++)
-            if (atof (opts->bandwidth) != pfb[n].stn[0].bw)
+            if (filteredbw != pfb[n].stn[0].bw)
                 {
                 for (i=n; i<nprod-1; i++) // slide remaining entries down one location
                     pfb[i] = pfb[i+1];
@@ -324,8 +324,8 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                 n--;                      //need to reexamine this slot now
                 nbw++;
                 }
-        fprintf (stderr, "%d correlation product channels deleted due to bw not %s\n",
-                 nbw, opts->bandwidth);
+        fprintf (stderr, "%d correlation product channels deleted due to bw not %s (parsed as ~%.6f)\n",
+                 nbw, opts->bandwidth, filteredbw);
         }
 
     if (opts->verbose > 1)

--- a/applications/difx2mark4/src/fill_fblock.c
+++ b/applications/difx2mark4/src/fill_fblock.c
@@ -120,7 +120,7 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                 pfb[nprod].stn[0].bw       = pfrAB->bw;
                 pfb[nprod].stn[0].bs       = pdsA->quantBits;
                 pfb[nprod].stn[0].zoom     = zoomA;
-                pfb[nprod].stn[0].pcal_int = pdsA->phaseCalIntervalMHz;
+                pfb[nprod].stn[0].pcal_int = pdsA->phaseCalIntervalMHz / pdsA->phaseCalIntervalDivisor;
                 pfb[nprod].stn[0].n_spec_chan = pfrAB->nChan / pfrAB->specAvg;
                 pfb[nprod].stn[1].pol      = polB;
                 pfb[nprod].stn[1].ant      = pdsB->antennaId;
@@ -131,7 +131,7 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                 pfb[nprod].stn[1].bw       = pfrAB->bw;
                 pfb[nprod].stn[1].bs       = pdsB->quantBits;
                 pfb[nprod].stn[1].zoom     = zoomB;
-                pfb[nprod].stn[1].pcal_int = pdsB->phaseCalIntervalMHz;
+                pfb[nprod].stn[1].pcal_int = pdsB->phaseCalIntervalMHz / pdsB->phaseCalIntervalDivisor;
                 pfb[nprod].stn[1].n_spec_chan = pfrAB->nChan / pfrAB->specAvg;
 
                                 // store info of the destination product i.e. output band, if new,

--- a/applications/difx2mark4/src/fill_fblock.c
+++ b/applications/difx2mark4/src/fill_fblock.c
@@ -40,7 +40,8 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
          buff[6];
 
     double temp,
-           freqs[MAX_DFRQ];
+           freqs[MAX_DFRQ],
+           filteredbw = 0.0;
 
     DifxBaseline *pbl;
     DifxDatastream *pdsA,
@@ -48,6 +49,11 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
     DifxFreq *pfr,
              *pdfr;
 
+                                    // bandwidth-based filtering option?
+    if (strlen (opts->bandwidth) != 0)
+        filteredbw = atof (opts->bandwidth);
+    else
+        filteredbw = 0.0;
 
                                     // first fill in the frequency block structure
     for (n=0; n<D->nBaseline; n++)
@@ -233,7 +239,8 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                                     // everywhere that ant & freq match
             for (n=0; n<nprod; n++)
                 for (k=0; k<2; k++)     // k = 0|1 for ref|rem antenna
-                    if (pfb[n].stn[k].ant == i && pfb[n].stn[k].freq == freqs[j])
+                    if (pfb[n].stn[k].ant == i && pfb[n].stn[k].freq == freqs[j]
+                        && (filteredbw <= 0.0 || pfb[n].stn[k].bw == filteredbw))
                         {
                         buff[3] = pfb[n].stn[k].sideband;
                         buff[4] = pfb[n].stn[k].pol;

--- a/applications/difx2mark4/src/fill_fblock.c
+++ b/applications/difx2mark4/src/fill_fblock.c
@@ -2,6 +2,7 @@
 // and how they were correlated. It then puts the information into an easy-to-use
 // frequency structure
 
+#include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -113,11 +114,16 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                     pfrB = D->freq + irfBfid;
                     }
 
+                                    // sanity check
+                assert(!pfb[nprod].stn[0].zoom || (pfb[nprod].stn[0].zoom && pfb[nprod].stn[0].sideband == 'U'));
+                assert(!pfb[nprod].stn[1].zoom || (pfb[nprod].stn[1].zoom && pfb[nprod].stn[1].sideband == 'U'));
+
                                     // info of output band
                 pfb[nprod].stn[0].pol      = polA;
                 pfb[nprod].stn[0].ant      = pdsA->antennaId;
                 pfb[nprod].stn[0].find     = irfAfid;
                 pfb[nprod].stn[0].fdest    = irfABfid;
+                pfb[nprod].stn[0].fmk4     = -1;
                 pfb[nprod].stn[0].freq     = pfrAB->freq;
                 pfb[nprod].stn[0].sideband = pfrAB->sideband;
                 pfb[nprod].stn[0].bw       = pfrAB->bw;
@@ -129,6 +135,7 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                 pfb[nprod].stn[1].ant      = pdsB->antennaId;
                 pfb[nprod].stn[1].find     = irfBfid;
                 pfb[nprod].stn[1].fdest    = irfABfid;
+                pfb[nprod].stn[1].fmk4     = -1;
                 pfb[nprod].stn[1].freq     = pfrAB->freq;
                 pfb[nprod].stn[1].sideband = pfrAB->sideband;
                 pfb[nprod].stn[1].bw       = pfrAB->bw;

--- a/applications/difx2mark4/src/fill_fblock.c
+++ b/applications/difx2mark4/src/fill_fblock.c
@@ -143,47 +143,46 @@ int fill_fblock (DifxInput *D,                    // difx input structure pointe
                             pfb[nprod].stn[k].sideband = 'U';
                             }
 
-                                    // store info of the product if indeed unique
-                if (!fblock_already_exists(pfb, nprod, &pfb[nprod]))
-                    {
-                    ++nprod;
-                    }
-
-                                    // if the baseline product is a slice within a wider output band,
-                                    // register also the output band, if it is new
-                if (irfAfid != idfABfid || irfBfid != idfABfid)
-                    {
-                    pfb[nprod].stn[0].pol      = polA;
-                    pfb[nprod].stn[0].ant      = pdsA->antennaId;
-                    pfb[nprod].stn[0].find     = idfABfid;
-                    pfb[nprod].stn[0].fdest    = idfABfid;
-                    pfb[nprod].stn[0].freq     = pdfr->freq;
-                    pfb[nprod].stn[0].sideband = pdfr->sideband;
-                    pfb[nprod].stn[0].bw       = pdfr->bw;
-                    pfb[nprod].stn[0].bs       = pdsA->quantBits;
-                    pfb[nprod].stn[0].zoom     = TRUE;
-                    pfb[nprod].stn[0].pcal_int = 0; // or pdsA->phaseCalIntervalMHz?
-                    pfb[nprod].stn[0].n_spec_chan = pdfr->nChan / pdfr->specAvg;
-                    pfb[nprod].stn[1].pol      = polB;
-                    pfb[nprod].stn[1].ant      = pdsB->antennaId;
-                    pfb[nprod].stn[1].find     = idfABfid;
-                    pfb[nprod].stn[1].fdest    = idfABfid;
-                    pfb[nprod].stn[1].freq     = pdfr->freq;
-                    pfb[nprod].stn[1].sideband = pdfr->sideband;
-                    pfb[nprod].stn[1].bw       = pdfr->bw;
-                    pfb[nprod].stn[1].bs       = pdsB->quantBits;
-                    pfb[nprod].stn[1].zoom     = TRUE;
-                    pfb[nprod].stn[1].pcal_int = 0; // or pdsB->phaseCalIntervalMHz?
-                    pfb[nprod].stn[1].n_spec_chan = pdfr->nChan / pdfr->specAvg;
+                                    // store info of the product itself, if new
+                                    // and if bw's of origin and destination are consistent
+                                    // NB: a narrower origin indicates its a slice within a wider destination,
+                                    // and the origin is an mpifxcorr-internal product absent from SWIN data
+                if (D->freq[irfAfid].bw == D->freq[idfABfid].bw && D->freq[irfBfid].bw == D->freq[idfABfid].bw)
                     if (!fblock_already_exists(pfb, nprod, &pfb[nprod]))
-                        {
                         ++nprod;
-                        }
-                    }
 
+                                    // info of output band
+                pfb[nprod].stn[0].pol      = polA;
+                pfb[nprod].stn[0].ant      = pdsA->antennaId;
+                pfb[nprod].stn[0].find     = idfABfid;
+                pfb[nprod].stn[0].fdest    = idfABfid;
+                pfb[nprod].stn[0].freq     = pdfr->freq;
+                pfb[nprod].stn[0].sideband = pdfr->sideband;
+                pfb[nprod].stn[0].bw       = pdfr->bw;
+                pfb[nprod].stn[0].bs       = pdsA->quantBits;
+                pfb[nprod].stn[0].zoom     = TRUE;
+                pfb[nprod].stn[0].pcal_int = pdsA->phaseCalIntervalMHz;
+                pfb[nprod].stn[0].n_spec_chan = pdfr->nChan / pdfr->specAvg;
+                pfb[nprod].stn[1].pol      = polB;
+                pfb[nprod].stn[1].ant      = pdsB->antennaId;
+                pfb[nprod].stn[1].find     = idfABfid;
+                pfb[nprod].stn[1].fdest    = idfABfid;
+                pfb[nprod].stn[1].freq     = pdfr->freq;
+                pfb[nprod].stn[1].sideband = pdfr->sideband;
+                pfb[nprod].stn[1].bw       = pdfr->bw;
+                pfb[nprod].stn[1].bs       = pdsB->quantBits;
+                pfb[nprod].stn[1].zoom     = TRUE;
+                pfb[nprod].stn[1].pcal_int = pdsB->phaseCalIntervalMHz;
+                pfb[nprod].stn[1].n_spec_chan = pdfr->nChan / pdfr->specAvg;
+
+                                // store info of the destination product i.e. output band, if new,
+                                // and if not itself already covered by the source product stored higher above
+                if (D->freq[irfAfid].bw != D->freq[idfABfid].bw || D->freq[irfBfid].bw != D->freq[idfABfid].bw)
+                    if (!fblock_already_exists(pfb, nprod, &pfb[nprod]))
+                        ++nprod;
 
                                     // check product index
-                if (nprod > MAX_FPPAIRS)
+                if (nprod > MAX_FPPAIRS-1)
                     {
                     printf ("too many freq-polpair combos; redimension\n");
                     return -1;

--- a/applications/difx2mark4/src/get_vis.c
+++ b/applications/difx2mark4/src/get_vis.c
@@ -231,11 +231,15 @@ int get_pfb_index (int baseline,    // difx-encoded baseline (100 * a1 + a2)
     while (pfb[++nf].stn[0].ant >= 0) // check for end-of-table marker
         {
         if (256 * (pfb[nf].stn[0].ant + 1) + pfb[nf].stn[1].ant + 1 == baseline
-          && (freq_index == pfb[nf].stn[0].find || freq_index == pfb[nf].stn[1].find))
+          && (freq_index == pfb[nf].stn[0].fdest || freq_index == pfb[nf].stn[1].fdest
+           || freq_index == pfb[nf].stn[0].find  || freq_index == pfb[nf].stn[1].find))
             return nf;
+
                                     // baseline didn't match, if it's an auto-correlation
         if (a1 == a2                // need to match one antenna and freq index
-         && (pfb[nf].stn[0].ant == a1 && freq_index == pfb[nf].stn[0].find 
+         && (pfb[nf].stn[0].ant == a1 && freq_index == pfb[nf].stn[0].fdest
+          || pfb[nf].stn[1].ant == a1 && freq_index == pfb[nf].stn[1].fdest
+          || pfb[nf].stn[0].ant == a1 && freq_index == pfb[nf].stn[0].find
           || pfb[nf].stn[1].ant == a1 && freq_index == pfb[nf].stn[1].find))
             return nf;
         }

--- a/applications/difx2mark4/src/get_vis.c
+++ b/applications/difx2mark4/src/get_vis.c
@@ -146,20 +146,20 @@ int get_vis (DifxInput *D,                    // ptr to difx input file data
                 if (ipfb < 0)
                     {
                     if (opts->verbose > 2)
-                        fprintf (stderr, "Skipping data for index %d of baseline %d\n",
-                                  pv->freq_index, pv->baseline);
+                        fprintf (stderr, "Skipping data for DiFX baseline %d frequency index %d %cSB %c%c lacking mk4 fblock entry\n",
+                                 pv->baseline, pv->freq_index, D->freq[pv->freq_index].sideband, pv->pols[0], pv->pols[1]);
                     nskip++;
                     continue;
-                    }   
+                    }
                 if (opts->verbose > 2)
-                    fprintf (stderr, "valid read bl %x time %d %13.6f %p config %d source %d "
-                                     "freq %d, pol %c%c pb %d\n",
-                    pv->baseline, pv->mjd, pv->iat, &(pv->iat),pv->config_index,
-                    pv->source_index, pv->freq_index, pv->pols[0], pv->pols[1], pv->pulsar_bin);
+                    fprintf (stderr, "valid read bl 0x%x time %d %13.6f %p config %d source %d "
+                                     "freq %d %cSB pol %c%c bin %d fblock[%04d]\n",
+                    pv->baseline, pv->mjd, pv->iat, &(pv->iat), pv->config_index,
+                    pv->source_index, pv->freq_index, D->freq[pv->freq_index].sideband, pv->pols[0], pv->pols[1], pv->pulsar_bin, ipfb);
                 }
             else
                 {
-                fprintf(stderr, "Error parsing Swinburne header: got a sync of %x and version"
+                fprintf(stderr, "Error parsing Swinburne header: got a sync of 0x%x and version"
                         " of %d in record %d\n", pv->sync, pv->version, nvr);
                 return -4;
                 }
@@ -167,7 +167,7 @@ int get_vis (DifxInput *D,                    // ptr to difx input file data
         else
             {
             fprintf (stderr, "Error parsing Swinburne header: got an unrecognized sync"
-                    " of %x in record %d\n", pv->sync, nvr);
+                    " of 0x%x in record %d\n", pv->sync, nvr);
             return -5;
             }
      
@@ -231,16 +231,13 @@ int get_pfb_index (int baseline,    // difx-encoded baseline (100 * a1 + a2)
     while (pfb[++nf].stn[0].ant >= 0) // check for end-of-table marker
         {
         if (256 * (pfb[nf].stn[0].ant + 1) + pfb[nf].stn[1].ant + 1 == baseline
-          && (freq_index == pfb[nf].stn[0].fdest || freq_index == pfb[nf].stn[1].fdest
-           || freq_index == pfb[nf].stn[0].find  || freq_index == pfb[nf].stn[1].find))
+          && (freq_index == pfb[nf].stn[0].fdest || freq_index == pfb[nf].stn[1].fdest))
             return nf;
 
                                     // baseline didn't match, if it's an auto-correlation
         if (a1 == a2                // need to match one antenna and freq index
          && (pfb[nf].stn[0].ant == a1 && freq_index == pfb[nf].stn[0].fdest
-          || pfb[nf].stn[1].ant == a1 && freq_index == pfb[nf].stn[1].fdest
-          || pfb[nf].stn[0].ant == a1 && freq_index == pfb[nf].stn[0].find
-          || pfb[nf].stn[1].ant == a1 && freq_index == pfb[nf].stn[1].find))
+          || pfb[nf].stn[1].ant == a1 && freq_index == pfb[nf].stn[1].fdest))
             return nf;
         }
 

--- a/applications/difx2mark4/src/new_type1.c
+++ b/applications/difx2mark4/src/new_type1.c
@@ -159,7 +159,7 @@ int new_type1 (DifxInput *D,                    // ptr to a filled-out difx inpu
                     }
                 if (ref >= 0 && rem >= 0)
                     {
-                    put_t101 (&t101, fout[nb], pfb[n].stn[0].fdest,
+                    put_t101 (&t101, fout[nb], pfb[n].stn[0].fmk4,
                               pfb[n].stn[0].chan_id, pfb[n].stn[1].chan_id);
                     scale_factor[nb] = SCALE * factor[pfb[n].stn[0].bs - 1]
                                              * factor[pfb[n].stn[1].bs - 1];
@@ -179,7 +179,7 @@ int new_type1 (DifxInput *D,                    // ptr to a filled-out difx inpu
                                     // first time antenna match?
                 if (a1 == pfb[n].stn[is].ant && pfb[n].stn[is].first_time)
                     {
-                    put_t101 (&t101, fout[nb], pfb[n].stn[is].fdest,
+                    put_t101 (&t101, fout[nb], pfb[n].stn[is].fmk4,
                               pfb[n].stn[is].chan_id, pfb[n].stn[is].chan_id);
                     scale_factor[nb] = SCALE;
                                     // form cross-pol chan_id string 
@@ -214,7 +214,7 @@ int new_type1 (DifxInput *D,                    // ptr to a filled-out difx inpu
                           && pfb[m].stn[1].ant == a1
                           && pfb[m].stn[1].first_time))
                             {
-                            put_t101 (&t101, fout[nb], pfb[n].stn[is].fdest,
+                            put_t101 (&t101, fout[nb], pfb[n].stn[is].fmk4,
                                       pfb[n].stn[is].chan_id, xpol_string);
                             }
                     }

--- a/applications/difx2mark4/src/new_type1.c
+++ b/applications/difx2mark4/src/new_type1.c
@@ -22,6 +22,8 @@
 
 #define SCALE 10000.0               // amplitude factor to normalize for fourfit
 
+static int CalculateNIndex(const DifxInput *D, int a1, int a2);
+
 int new_type1 (DifxInput *D,                    // ptr to a filled-out difx input structure
                struct fblock_tag *pfb,          // ptr to filled-in fblock table
                int nb,                          // (next open) index to base_index array
@@ -133,7 +135,8 @@ int new_type1 (DifxInput *D,                    // ptr to a filled-out difx inpu
 
                                     // construct and write type 100 record
     memcpy (t100.baseline, blines+2*nb, 2);
-    t100.nindex = D->baseline[blind].nFreq * D->baseline[blind].nPolProd[0];
+    //t100.nindex = D->baseline[blind].nFreq * D->baseline[blind].nPolProd[0];
+    t100.nindex = CalculateNIndex(D, a1, a2);
     write_t100 (&t100, fout[nb]);
 
     if (a1 != a2)                   // cross-correlation
@@ -250,3 +253,27 @@ void put_t101 (struct type_101 *t101,
                                     // and write this type 101
     write_t101 (t101, fout);
     }
+
+//this function is needed to compute t100.nindex properly with multiple datastream
+//stations, previously d2m4 erroneously used:
+//nindex = D->baseline[blind].nFreq * D->baseline[blind].nPolProd[0];
+//which is correct when there is a single datastream containing all of the
+//frequencies and pol-products, but wrong for multi-stream station data
+static int CalculateNIndex(const DifxInput *D, int a1, int a2)
+{
+    int i;
+    int count = 0;
+    //if any antenna has multiple datastreams, we need
+    //to loop through all the 'baselines' and sum up nfreq*npolprods on each one
+    for (i=0; i<D->nBaseline; i++)
+    {
+        int dsant1 = D->datastream[D->baseline[i].dsA].antennaId;
+        int dsant2 = D->datastream[D->baseline[i].dsB].antennaId;
+        if( (dsant1 == a1 && dsant2 == a2) || (dsant1 == a2 && dsant2 == a1) )
+        {
+            count += D->baseline[i].nFreq * D->baseline[i].nPolProd[0];
+        }
+    }
+    return count;
+}
+

--- a/applications/difx2mark4/src/new_type1.c
+++ b/applications/difx2mark4/src/new_type1.c
@@ -159,7 +159,7 @@ int new_type1 (DifxInput *D,                    // ptr to a filled-out difx inpu
                     }
                 if (ref >= 0 && rem >= 0)
                     {
-                    put_t101 (&t101, fout[nb], pfb[n].stn[0].find,
+                    put_t101 (&t101, fout[nb], pfb[n].stn[0].fdest,
                               pfb[n].stn[0].chan_id, pfb[n].stn[1].chan_id);
                     scale_factor[nb] = SCALE * factor[pfb[n].stn[0].bs - 1]
                                              * factor[pfb[n].stn[1].bs - 1];
@@ -179,7 +179,7 @@ int new_type1 (DifxInput *D,                    // ptr to a filled-out difx inpu
                                     // first time antenna match?
                 if (a1 == pfb[n].stn[is].ant && pfb[n].stn[is].first_time)
                     {
-                    put_t101 (&t101, fout[nb], pfb[n].stn[is].find,
+                    put_t101 (&t101, fout[nb], pfb[n].stn[is].fdest,
                               pfb[n].stn[is].chan_id, pfb[n].stn[is].chan_id);
                     scale_factor[nb] = SCALE;
                                     // form cross-pol chan_id string 
@@ -214,7 +214,7 @@ int new_type1 (DifxInput *D,                    // ptr to a filled-out difx inpu
                           && pfb[m].stn[1].ant == a1
                           && pfb[m].stn[1].first_time))
                             {
-                            put_t101 (&t101, fout[nb], pfb[n].stn[is].find,
+                            put_t101 (&t101, fout[nb], pfb[n].stn[is].fdest,
                                       pfb[n].stn[is].chan_id, xpol_string);
                             }
                     }

--- a/applications/difx2mark4/src/normalize.c
+++ b/applications/difx2mark4/src/normalize.c
@@ -66,7 +66,7 @@ void normalize (const DifxInput * D,              // ptr to a filled-out difx in
             continue;
         for (n=i+1; n < D->nFreq && n < MAX_DFRQ; n++)
             if (isSameDifxFreq(&D->freq[i], &D->freq[n], /*ignore pcal:*/1))
-               pmap[i] = n;
+               pmap[n] = i;
         }
 
                                     // initialize for looping 

--- a/applications/difx2mark4/src/type_309.h
+++ b/applications/difx2mark4/src/type_309.h
@@ -42,8 +42,8 @@ struct type_309
     {
     char      chan_name[8];
     double    freq;                   // tone frequency in Hz
-    U32       acc[64][2];             // accumulators for 64 freqs x 2 quads (C..S)
-    } chan[64];
+    U32       acc[NPC_TONES][2];      // accumulators for 64 freqs x 2 quads (C..S)
+    } chan[NPC_FREQS];
   };
 void write_t309 (struct type_309 *, FILE *);
 

--- a/applications/difx2mark4/src/write_t309.c
+++ b/applications/difx2mark4/src/write_t309.c
@@ -19,10 +19,10 @@ void write_t309 (struct type_309 *pt309,
     t309.rot         = double_reverse (pt309->rot);
     t309.acc_period  = double_reverse (pt309->acc_period);
 
-    for (i=0; i<64; i++)
+    for (i=0; i<NPC_FREQS; i++)
         {
         t309.chan[i].freq = double_reverse (pt309->chan[i].freq);
-        for (j=0; j<64; j++)
+        for (j=0; j<NPC_TONES; j++)
             {
             t309.chan[i].acc[j][0] = int_reverse (t309.chan[i].acc[j][0]);
             t309.chan[i].acc[j][1] = int_reverse (t309.chan[i].acc[j][1]);


### PR DESCRIPTION

A set of fixes for difx2mark4.

Pending review by John Barrett, and additional testing with geodetic mixed-mode R1 experiments.

So far tested as a working fix for the geodetic R1 experiment r11094, and as not breaking the astronomical e22d23.

The main fix corrects an issue with a lack of amplitude scaling - a failed visibility normalization. It was encountered in a  "mixed-mode" geodetic experiment similar to r11094 under difx2mark4 of DiFX-2.8.

The affected R1 tracks do not use outputbands nor zoom bands, nevertheless, the initial suspicion was that the scaling bug was related to outputband code. The pull request contains a few "unrelated" fixes found necessary along the way while looking for the actual cause of the scaling issue.

The fixes in the pull request cover:
 - improvements to frequency table bookkeeping in fill_block.c (6ae8db3, a1514c4)
 - fix of an issue in the '-w <bandwidth MHz>' filtering option (9340528, 06b6a83) when zoom bands are at the same sky frequencies as the wider recorded bands; only recorded bands got considered because they are encountered first in the DiFX frequency table, the later zoom freq entries were ignored, and option -w then dropped even the recorded bands, resulting in a Mk4 root with a blank $FREQ
- the *actual* fix for the amplitude normalization issue (65824ae, 9ec4281); autocorrelations needed by the normalization code can have a different DiFX frequency table id at every station, but difx2mark failed to consider more than 1-2 frequency IDs in the autocorrelation data search.

The key problem turned out to be PCal information and how vex2difx by design creates duplicate/multiple frequency table entries. Every station having an identical frequency setup but a different PCal spacing leads to copies of the existing frequency entries.

The affected R1 had 3 different PCal setups

```
oper@fxmanager: r11094> grep -h "CAL INT" test/*.input | sort |uniq
PHASE CAL INT (MHZ):1
PHASE CAL INT (MHZ):5
PHASE CAL INT (MHZ):10
```

causing vex2difx to (correctly/by design) create 3 entries for the same frequency

```
oper@fxmanager: r11094> printDiFXInput.py --freqs test/r11094_0025.input | grep 8212.99 | grep USB
  fq   0 :      8.000000 MHz USB [ 128-ch/2-avg] @ 8212.990000 MHz
  fq  16 :      8.000000 MHz USB [ 128-ch/2-avg] @ 8212.990000 MHz
  fq  32 :      8.000000 MHz USB [ 128-ch/2-avg] @ 8212.990000 MHz
```
Autocorrelations in SWIN data for that single frequency thus had freq IDs of 0, 16, or 32, depending on the station.

Visibility normalization in difx2mark4 normalize.c for, e.g., a SWIN visibility record with freq ID 0 failed to associate that record with autocorrelations from the reference station having freq id 16 and at the remote station having freq id 32.

The fix enhances the frequency id remapping table (which was already in normalize.c). Now all in a sense redundant freq ids get mapped back to the id of the very first occurrence, and the lookup of autocorrelations in normalize.c succeeds.