### PR TITLE
Feature visibilitycpp clean-up and fix for skipped autocorrelations

### DIFF
--- a/mpifxcorr/src/configuration.cpp
+++ b/mpifxcorr/src/configuration.cpp
@@ -406,6 +406,7 @@ Configuration::~Configuration()
       delete [] configs[i].frequsedbysomebaseline;
       delete [] configs[i].equivfrequsedbysomebaseline;
       delete [] configs[i].freqoutputbysomebaseline;
+      delete [] configs[i].equivfreqoutputbysomebaseline;
       for(int j=0;j<freqtablelength;j++) {
         delete [] configs[i].frequsedbybaseline[j];
         delete [] configs[i].equivfrequsedbybaseline[j];
@@ -2265,10 +2266,12 @@ bool Configuration::populateFrequencyDetails()
     configs[i].frequsedbysomebaseline = new bool[freqtablelength]();
     configs[i].equivfrequsedbysomebaseline = new bool[freqtablelength]();
     configs[i].freqoutputbysomebaseline = new bool[freqtablelength]();
+    configs[i].equivfreqoutputbysomebaseline = new bool[freqtablelength]();
     for(int j=0;j<freqtablelength;j++) {
       configs[i].frequsedbysomebaseline[j] = false;
       configs[i].equivfrequsedbysomebaseline[j] = false;
       configs[i].freqoutputbysomebaseline[j] = false;
+      configs[i].equivfreqoutputbysomebaseline[j] = false;
     }
     configs[i].frequsedbybaseline = new bool*[freqtablelength]();
     configs[i].equivfrequsedbybaseline = new bool*[freqtablelength]();
@@ -2294,11 +2297,11 @@ bool Configuration::populateFrequencyDetails()
     }
   }
 
-  //for each freq, check if an equivalent frequency is used, to ensure autocorrelations also get sent where required
+  //for each freq, check if an equivalent frequency is used or is output, to ensure autocorrelations also get sent where required
   double bwdiff, freqdiff;
   for(int i=0;i<numconfigs;i++) {
     for(int j=0;j<freqtablelength;j++) {
-      if(!configs[i].frequsedbysomebaseline[j]) {
+      if(!configs[i].frequsedbysomebaseline[j] || !configs[i].freqoutputbysomebaseline[j]) {
         for(int k=0;k<freqtablelength;k++) {
           bwdiff = freqtable[j].bandwidth - freqtable[k].bandwidth;
           freqdiff = freqtable[j].bandedgefreq - freqtable[k].bandedgefreq;
@@ -2314,6 +2317,8 @@ bool Configuration::populateFrequencyDetails()
           {
             if(configs[i].frequsedbysomebaseline[k])
               configs[i].equivfrequsedbysomebaseline[j] = true;
+            if(configs[i].freqoutputbysomebaseline[k])
+              configs[i].equivfreqoutputbysomebaseline[j] = true;
           }
         }
       }

--- a/mpifxcorr/src/configuration.h
+++ b/mpifxcorr/src/configuration.h
@@ -354,6 +354,8 @@ public:
     { return configs[configindex].equivfrequsedbysomebaseline[freqindex]; }
   inline bool isFrequencyOutput(int configindex, int freqindex) const
     { return configs[configindex].freqoutputbysomebaseline[freqindex]; }
+  inline bool isEquivalentFrequencyOutput(int configindex, int freqindex) const
+    { return configs[configindex].equivfreqoutputbysomebaseline[freqindex]; }
   inline bool isFrequencyOutput(int configindex, int baselineindex, int freqindex) const
     { return configs[configindex].freqoutputbybaseline[freqindex][baselineindex]; }
   inline bool isBFrequencyUsed(int configindex, int configbaselineindex, int freqindex) const
@@ -846,6 +848,7 @@ private:
     bool * frequsedbysomebaseline;
     bool * equivfrequsedbysomebaseline;
     bool * freqoutputbysomebaseline;
+    bool * equivfreqoutputbysomebaseline;
     //finer bookkeeping of freqs
     bool ** frequsedbybaseline;         //[freq][baseline]
     bool ** equivfrequsedbybaseline;    //[freq][baseline]

--- a/mpifxcorr/src/visibility.cpp
+++ b/mpifxcorr/src/visibility.cpp
@@ -43,10 +43,22 @@
 #include <difxmessage.h>
 #include "alert.h"
 
+#ifndef MAX_PATH
+#define MAX_PATH 256
+#endif
+
+//static string sec2time(const int& sec)
+//{
+//  ostringstream oss;
+//  oss << setfill('0');
+//  oss << setw(2) << sec/3600 << ":" << setw(2) << (sec/60)%60 << ":" << setw(2) << sec%60;
+//  return oss.str();
+//}
+
 Visibility::Visibility(Configuration * conf, int id, int numvis, char * dbuffer, int dbufferlen, int eseconds, int scan, int scanstartsec, int startns, const string * pnames)
   : config(conf), visID(id), currentscan(scan), currentstartseconds(scanstartsec), currentstartns(startns), numvisibilities(numvis), executeseconds(eseconds), todiskbufferlength(dbufferlen), polnames(pnames), todiskbuffer(dbuffer)
 {
-  int status, binloop, maxbinloop = 1;
+  int binloop, status;
 
   //cverbose << startl << "About to create visibility " << id << "/" << numvis << endl;
   estimatedbytes = 0;
@@ -75,6 +87,7 @@ Visibility::Visibility(Configuration * conf, int id, int numvis, char * dbuffer,
   offsetns = 0;
   changeConfig(currentconfigindex);
   maxfiles = 1;
+  maxbinloop = 1;
   for(int i=0;i<model->getNumScans();i++)
   {
     binloop = 1;
@@ -103,7 +116,7 @@ Visibility::Visibility(Configuration * conf, int id, int numvis, char * dbuffer,
 // Note: not to be called until .difx/ dir is created.
 void Visibility::initialisePcalFiles()
 {
-  char pcalfilename[256];
+  char pcalfilename[MAX_PATH];
   ofstream pcaloutput;
   set<string> completedstations;
 
@@ -113,7 +126,7 @@ void Visibility::initialisePcalFiles()
     for(int c=0;c<config->getNumConfigs();c++)
     {
       if(completedstations.find(config->getDStationName(c, i)) != completedstations.end())
-        continue;	
+        continue;
       if(config->getDPhaseCalIntervalHz(c, i) > 0)
       {
         sprintf(pcalfilename, "%s/PCAL_%05d_%06d_%s", config->getOutputFilename().c_str(), config->getStartMJD(), config->getStartSeconds(), config->getDStationName(c, i).c_str());
@@ -134,7 +147,7 @@ void Visibility::initialisePcalFiles()
       }
     }
   }
-}       
+}
 
 Visibility::~Visibility()
 {
@@ -199,13 +212,6 @@ bool Visibility::addData(cf32* subintresults)
     cwarn << startl << "Somehow Visibility " << visID << " ended up with " << currentsubints << " subintegrations - was expecting only " << subintsthisintegration << endl;
 
   return (currentsubints>=subintsthisintegration); //are we finished integrating?
-}
-
-string sec2time(const int& sec) {
-  ostringstream oss;
-  oss << setfill('0');
-  oss << setw(2) << sec/3600 << ":" << setw(2) << (sec/60)%60 << ":" << setw(2) << sec%60; 
-  return oss.str();
 }
 
 void Visibility::increment()
@@ -309,7 +315,8 @@ void Visibility::updateTime()
   }
 }
 
-void Visibility::copyVisData(char **buf, int *bufsize, int *nbuf) {
+void Visibility::copyVisData(char **buf, int *bufsize, int *nbuf)
+{
   char *ptr;
   int ntowrite;
   int32_t atsec, datasize;
@@ -361,7 +368,7 @@ void Visibility::writedata()
   int dumpmjd, intsec;
   double dumpseconds, acw;
 
-//  cdebug << startl << "Vis. " << visID << " is starting to write out data" << endl;
+  //cdebug << startl << "Vis. " << visID << " is starting to write out data" << endl;
 
   if(currentscan >= model->getNumScans() || currentstartseconds + model->getScanStartSec(currentscan, expermjd, experseconds) >= executeseconds)
   {
@@ -437,7 +444,7 @@ void Visibility::writedata()
         for(int s=0;s<model->getNumPhaseCentres(currentscan);s++) {
           //its in units of integration width in ns, so scale to get something which is 1.0 for no decorrelation
           baselineshiftdecorrs[i][freqindex][s] = floatresults[resultindex]/(1000000000.0*config->getIntTime(currentconfigindex));
-//TODO: when targetfreq != freqindex, what to do, multiply-in/average to form decorr for N:1 freq:targetfreq case?
+          //TODO: when targetfreq != freqindex, what to do, multiply-in/average to form decorr for N:1 freq:targetfreq case?
           baselineshiftdecorrs[i][targetfreqindex][s] = baselineshiftdecorrs[i][freqindex][s];
           resultindex++;
         }
@@ -680,16 +687,16 @@ void Visibility::writedata()
 
   //all calibrated, now just need to write out
   if(config->getOutputFormat() == Configuration::DIFX)
-    writedifx(dumpmjd, dumpseconds);
+    writeSWIN(dumpmjd, dumpseconds);
   else
-    writeascii(dumpmjd, dumpseconds);
+    writeASCII(dumpmjd, dumpseconds);
 
-//  cdebug << startl << "Vis. " << visID << " has finished writing data" << endl;
+  //cdebug << startl << "Vis. " << visID << " has finished writing data" << endl;
 
   return;
 }
 
-void Visibility::writeascii(int dumpmjd, double dumpseconds)
+void Visibility::writeASCII(int dumpmjd, double dumpseconds)
 {
   ofstream output;
   int binloop, freqchannels, freqindex, targetfreqindex;
@@ -710,7 +717,7 @@ void Visibility::writeascii(int dumpmjd, double dumpseconds)
   }
   sprintf(datetimestring, "%05u_%02u%02u%02u_%06u", mjd, hours, minutes, seconds, microseconds);
   cinfo << startl << "Mjd is " << mjd << ", hours is " << hours << ", minutes is " << minutes << ", seconds is " << seconds << endl;
-  
+
   if(config->pulsarBinOn(currentconfigindex) && !config->scrunchOutputOn(currentconfigindex))
     binloop = config->getNumPulsarBins(currentconfigindex);
   else
@@ -730,12 +737,9 @@ void Visibility::writeascii(int dumpmjd, double dumpseconds)
         {
           for(int k=0;k<config->getBNumPolProducts(currentconfigindex, i, j);k++)
           {
-	    stringstream fname;
             //write out to a naive filename
-
-	    fname << "baseline_" << i << "_freq_" << j << "_product_" << k << "_" << datetimestring << "_source_" << s << "_bin_" << b << ".output";
-
-            //output.open(string(string("baseline_")+itoa(i,sbuf,10)+"_freq_"+char('0' + j)+"_product_"+char('0'+k)+"_"+datetimestring+"_source_"+char('0'+s)+"_bin_"+char('0'+b)+".output").c_str(), ios::out|ios::trunc);
+            stringstream fname;
+            fname << "baseline_" << i << "_freq_" << j << "_product_" << k << "_" << datetimestring << "_source_" << s << "_bin_" << b << ".output";
             output.open(fname.str().c_str(), ios::out|ios::trunc);
             for(int l=0;l<freqchannels;l++) {
               atindex = resultindex+l;
@@ -762,12 +766,11 @@ void Visibility::writeascii(int dumpmjd, double dumpseconds)
         {
           freqindex = config->getDTotalFreqIndex(currentconfigindex, i, k);
           if(config->isFrequencyUsed(currentconfigindex, freqindex) || config->isEquivalentFrequencyUsed(currentconfigindex, freqindex)) {
-	    stringstream fname;
+            stringstream fname;
             freqchannels = config->getFNumChannels(freqindex)/config->getFChannelsToAverage(freqindex);
             //write out to naive filename
             fname << "datastream_" << i << "_crosspolar_" << j << "_product_" << k << "_" << datetimestring << "_bin_" << 0 << ".output";
             output.open(fname.str().c_str(), ios::out|ios::trunc);
-	    //            output.open(string(string("datastream_")+char('0' + i)+"_crosspolar_"+char('0' + j)+"_product_"+char('0'+k)+"_"+datetimestring+"_bin_"+char('0'+0)+".output").c_str(), ios::out|ios::trunc);
             for(int l=0;l<freqchannels;l++) {
               atindex = resultindex + l;
               output << l << " " << sqrt(results[atindex].re*results[atindex].re + results[atindex].im*results[atindex].im) << " " << atan2(results[atindex].im, results[atindex].re) << endl;
@@ -783,12 +786,10 @@ void Visibility::writeascii(int dumpmjd, double dumpseconds)
   }
 }
 
-void Visibility::writedifx(int dumpmjd, double dumpseconds)
+void Visibility::writeSWIN(int dumpmjd, double dumpseconds)
 {
-  ofstream output;
   ofstream pcaloutput;
-  char filename[256];
-  char pcalfilename[256];
+  char pcalfilename[MAX_PATH];
   char pcalstr[256];
   string pcalline;
   int binloop, freqindex, baselinefreqindex, numpolproducts, resultindex, coreindex, coreoffset, freqchannels;
@@ -870,7 +871,6 @@ void Visibility::writedifx(int dumpmjd, double dumpseconds)
             // follow core.cpp indexing
             coreoffset = (b*numpolproducts + k)*freqchannels;
 
-            //open the file for appending in ascii and write the ascii header
             if(baselineweights[i][freqindex][b][k] > 0.0)
             {
               //cout << "About to write out baseline[" << i << "][" << s << "][" << k << "] from coreindex " << coreindex+coreoffset << ", whose 6th vis is " << results[coreindex+correoffset+6].re << " + " << results[coreindex+coreoffset+6].im << " i" << endl;
@@ -878,19 +878,14 @@ void Visibility::writedifx(int dumpmjd, double dumpseconds)
                 currentweight = baselineweights[i][freqindex][b][k]*baselineshiftdecorrs[i][freqindex][s];
               else
                 currentweight = baselineweights[i][freqindex][b][k];
-              writeDiFXHeader(&output, baselinenumber, dumpmjd, dumpseconds, currentconfigindex, sourceindex, freqindex, polpair, b, 0, currentweight, buvw, filecount);
-
-              //close, reopen in binary and write the binary data, then close again
-              //For both USB and LSB data, the Nyquist channel has already been excised by Core. In
-              //the case of correlating USB with LSB data, the first datastream defines which is the 
+              appendSWINHeaderBuffered(baselinenumber, dumpmjd, dumpseconds, currentconfigindex, sourceindex, freqindex, polpair, b, 0, currentweight, buvw, filecount);
+              appendSWINDataBuffered(&(results[coreindex+coreoffset]), freqchannels*sizeof(cf32), filecount);
+              //Note: For both USB and LSB data, the Nyquist channel has already been excised by Core. In
+              //the case of correlating USB with LSB data, the first datastream defines which is the
               //Nyquist channels.  In any case, the numchannels that are written out represent the
               //the valid part of the, and run from lowest frequency to highest frequency.  For USB
               //data, the first channel is the DC - for LSB data, the last channel is the DC
-              //output.write((char*)(&(results[resultindex])), freqchannels*sizeof(cf32));
-              memcpy(&(todiskbuffer[todiskmemptrs[filecount]]), &(results[coreindex+coreoffset]), freqchannels*sizeof(cf32));
-              todiskmemptrs[filecount] += freqchannels*sizeof(cf32);
             }
-
             // NB: need a different increment? otoh maybe not, 'freqchannels' here === targetfreqchannels since this is a target freq
             resultindex += freqchannels;
           }//for(numpoln)
@@ -901,26 +896,15 @@ void Visibility::writedifx(int dumpmjd, double dumpseconds)
     }//for(freqs)
   }//for(baselines)
 
-  //now write all the different files out to disk, one hit per file
-  filecount = 0;
-  for(int s=0;s<model->getNumPhaseCentres(currentscan);s++)
-  {
-    for(int b=0;b<binloop;b++)
-    {
-      sprintf(filename, "%s/DIFX_%05d_%06d.s%04d.b%04d", config->getOutputFilename().c_str(), expermjd, experseconds, s, b);
-      output.open(filename, ios::app);
-      output.write(&(todiskbuffer[filecount*(todiskbufferlength/numfiles)]), todiskmemptrs[filecount]-filecount*(todiskbufferlength/numfiles));
-      output.close();
-      if(!output)
-         csevere << startl << "Error trying to write more data to " << filename << " : " << strerror(errno) << "!!" << endl;
-      filecount++;
-    }
-  }
+  //now write all the different files out to disk, multi-file, one hit per file
+  flushBuffersToDisk(true);
 
   if(model->getNumPhaseCentres(currentscan) == 1)
     sourceindex = model->getPhaseCentreSourceIndex(currentscan, 0);
   else
     sourceindex = model->getPointingCentreSourceIndex(currentscan);
+
+  filecount = 0;
   todiskmemptrs[0] = 0;
 
   //now each autocorrelation visibility point if necessary
@@ -950,7 +934,6 @@ void Visibility::writedifx(int dumpmjd, double dumpseconds)
             freqchannels = config->getFNumChannels(freqindex)/config->getFChannelsToAverage(freqindex);
             if(autocorrweights[i][j][k] > 0.0)
             {
-              //open, write the header and close
               if(k<config->getDNumRecordedBands(currentconfigindex, i))
                 polpair[0] = config->getDRecordedBandPol(currentconfigindex, i, k);
               else
@@ -959,13 +942,9 @@ void Visibility::writedifx(int dumpmjd, double dumpseconds)
                 polpair[1] = polpair[0];
               else
                 polpair[1] = config->getOppositePol(polpair[0]);
-              writeDiFXHeader(&output, baselinenumber, dumpmjd, dumpseconds, currentconfigindex, sourceindex, freqindex, polpair, 0, 0, autocorrweights[i][j][k], buvw, 0);
-
-              //open, write the binary data and close
-              //see baseline writing section for description of treatment of USB/LSB data and the Nyquist channel
-              //output.write((char*)(&(results[resultindex])), freqchannels*sizeof(cf32));
-              memcpy(&(todiskbuffer[todiskmemptrs[0]]), &(results[resultindex]), freqchannels*sizeof(cf32));
-              todiskmemptrs[0] += freqchannels*sizeof(cf32);
+              appendSWINHeaderBuffered(baselinenumber, dumpmjd, dumpseconds, currentconfigindex, sourceindex, freqindex, polpair, 0, 0, autocorrweights[i][j][k], buvw, filecount);
+              appendSWINDataBuffered(&(results[resultindex]), freqchannels*sizeof(cf32), filecount);
+              //nb: see baseline writing section for description of treatment of USB/LSB data and the Nyquist channel
             }
             resultindex += freqchannels;
           }
@@ -976,13 +955,8 @@ void Visibility::writedifx(int dumpmjd, double dumpseconds)
 
   if(todiskmemptrs[0] > 0)
   {
-    //write out the autocorrelations, all in one hit
-    sprintf(filename, "%s/DIFX_%05d_%06d.s%04d.b%04d", config->getOutputFilename().c_str(), expermjd, experseconds, 0, 0);
-    output.open(filename, ios::app);
-    output.write(todiskbuffer, todiskmemptrs[0]);
-    output.close();
-    if(!output)
-      csevere << startl << "Error trying to write more data to " << filename << " : " << strerror(errno) << "!!" << endl;
+    //write out the autocorrelations, all in one hit, not multi-file
+    flushBuffersToDisk(false);
   }
 
 
@@ -1086,6 +1060,43 @@ The four columns are:
   }
 }
 
+void Visibility::flushBuffersToDisk(bool multifile)
+{
+  char filename[MAX_PATH];
+  ofstream output;
+  if(multifile)
+  {
+    int filenr = 0, binloop = 1, numfiles = 1;
+
+    if(config->pulsarBinOn(currentconfigindex) && !config->scrunchOutputOn(currentconfigindex))
+      binloop = config->getNumPulsarBins(currentconfigindex);
+    numfiles = binloop*model->getNumPhaseCentres(currentscan);
+
+    for(int s=0;s<model->getNumPhaseCentres(currentscan);s++)
+    {
+        for(int b=0;b<binloop;b++)
+        {
+          sprintf(filename, "%s/DIFX_%05d_%06d.s%04d.b%04d", config->getOutputFilename().c_str(), config->getStartMJD(), config->getStartSeconds(), s, b);
+          output.open(filename, ios::app);
+          output.write(&(todiskbuffer[filenr*(todiskbufferlength/numfiles)]), todiskmemptrs[filenr] - filenr*(todiskbufferlength/numfiles));
+          output.close();
+          if(!output)
+            csevere << startl << "Error trying to write more data to " << filename << " : " << strerror(errno) << "!!" << endl;
+          filenr++;
+        }
+    }
+  }
+  else
+  {
+    sprintf(filename, "%s/DIFX_%05d_%06d.s%04d.b%04d", config->getOutputFilename().c_str(), config->getStartMJD(), config->getStartSeconds(), 0, 0);
+    output.open(filename, ios::app);
+    output.write(todiskbuffer, todiskmemptrs[0]);
+    output.close();
+    if(!output)
+      csevere << startl << "Error trying to write more data to " << filename << " : " << strerror(errno) << "!!" << endl;
+  }
+}
+
 void Visibility::multicastweights()
 {
   float *weight;
@@ -1136,13 +1147,14 @@ void Visibility::multicastweights()
   difxMessageSendDifxStatus3(DIFX_STATE_RUNNING, "", mjd, numdatastreams, weight, expermjd + experseconds/86400.0, expermjd + (experseconds + executeseconds)/86400.0);
 
   delete [] weight;
-} 
+}
 
-
-void Visibility::writeDiFXHeader(ofstream * output, int baselinenum, int dumpmjd, double dumpseconds, int configindex, int sourceindex, int freqindex, const char polproduct[3], int pulsarbin, int flag, float weight, double buvw[3], int filecount)
+// likely obsolete, ASCI output is unbuffered multi-file with no headers, cf. writeASCII()
+void Visibility::appendASCIIHeaderBuffered(int baselinenum, int dumpmjd, double dumpseconds, int configindex, int sourceindex, int freqindex, const char polproduct[3], int pulsarbin, int flag, float weight, double buvw[3], int filecount)
 {
   double dweight = weight;
-  /* *output << setprecision(15);
+  /*
+  *output << setprecision(15);
   *output << "BASELINE NUM:       " << baselinenum << endl;
   *output << "MJD:                " << dumpmjd << endl;
   *output << "SECONDS:            " << dumpseconds << endl;
@@ -1156,6 +1168,7 @@ void Visibility::writeDiFXHeader(ofstream * output, int baselinenum, int dumpmjd
   *output << "U (METRES):         " << buvw[0] << endl;
   *output << "V (METRES):         " << buvw[1] << endl;
   *output << "W (METRES):         " << buvw[2] << endl;
+  */
   sprintf(&(todiskbuffer[todiskmemptrs[filecount]]), "BASELINE NUM:       %d\n", baselinenum);
   todiskmemptrs[filecount] += strlen(&(todiskbuffer[todiskmemptrs[filecount]]));
   sprintf(&(todiskbuffer[todiskmemptrs[filecount]]), "MJD:                %d\n", dumpmjd);
@@ -1193,7 +1206,12 @@ void Visibility::writeDiFXHeader(ofstream * output, int baselinenum, int dumpmjd
     todiskmemptrs[filecount] += strlen(&(todiskbuffer[todiskmemptrs[filecount]]));
     sprintf(&(todiskbuffer[todiskmemptrs[filecount]]), "W (METRES):         0.0\n");
     todiskmemptrs[filecount] += strlen(&(todiskbuffer[todiskmemptrs[filecount]]));
-  }*/
+  }
+}
+
+void Visibility::appendSWINHeaderBuffered(int baselinenum, int dumpmjd, double dumpseconds, int configindex, int sourceindex, int freqindex, const char polproduct[3], int pulsarbin, int flag, float weight, double buvw[3], int filecount)
+{
+  double dweight = weight;
   *((unsigned int*)(&(todiskbuffer[todiskmemptrs[filecount]]))) = SYNC_WORD;
   todiskmemptrs[filecount] += 4;
   *((int*)(&(todiskbuffer[todiskmemptrs[filecount]]))) = BINARY_HEADER_VERSION;
@@ -1222,6 +1240,12 @@ void Visibility::writeDiFXHeader(ofstream * output, int baselinenum, int dumpmjd
   todiskmemptrs[filecount] += 3*8;
 }
 
+void Visibility::appendSWINDataBuffered(void * srcdata, size_t numbytes, int filecount)
+{
+  memcpy(&(todiskbuffer[todiskmemptrs[filecount]]), srcdata, numbytes);
+  todiskmemptrs[filecount] += numbytes;
+}
+
 void Visibility::changeConfig(int configindex)
 {
   int pulsarwidth;
@@ -1244,7 +1268,7 @@ void Visibility::changeConfig(int configindex)
     pulsarwidth = 1;
     if(pulsarbinon && !config->scrunchOutputOn(currentconfigindex))
       pulsarwidth = config->getNumPulsarBins(currentconfigindex);
-//    cverbose << startl << "Starting to delete some old arrays" << endl;
+//  cverbose << startl << "Starting to delete some old arrays" << endl;
     //need to delete the old arrays before allocating the new ones
     for(int i=0;i<numdatastreams;i++) {
       delete [] autocorrcalibs[i];
@@ -1390,4 +1414,5 @@ void Visibility::changeConfig(int configindex)
     cverbose << startl << "Finished the pulsar bin initialisation" << endl;
   }
 }
+
 // vim: shiftwidth=2:softtabstop=2:expandtab

--- a/mpifxcorr/src/visibility.cpp
+++ b/mpifxcorr/src/visibility.cpp
@@ -930,7 +930,7 @@ void Visibility::writeSWIN(int dumpmjd, double dumpseconds)
               freqindex = config->getDTotalFreqIndex(currentconfigindex, i, k);
             }
           }
-          if(config->isFrequencyOutput(currentconfigindex, freqindex)) {
+          if(config->isFrequencyOutput(currentconfigindex, freqindex) || config->isEquivalentFrequencyOutput(currentconfigindex, freqindex)) {
             freqchannels = config->getFNumChannels(freqindex)/config->getFChannelsToAverage(freqindex);
             if(autocorrweights[i][j][k] > 0.0)
             {

--- a/mpifxcorr/src/visibility.h
+++ b/mpifxcorr/src/visibility.h
@@ -174,20 +174,37 @@ private:
 /**
   * Writes the visibilities to disk in ascii format - only used for debugging
   */
-  void writeascii(int dumpmjd, double dumpseconds);
+  void writeASCII(int dumpmjd, double dumpseconds);
 
 /**
-  * Writes the visibilities to disk in DiFX format (binary with inserted ascii headers)
+  * Writes the visibilities to disk in DiFX SWIN format
   */
-  void writedifx(int dumpmjd, double dumpseconds);
+  void writeSWIN(int dumpmjd, double dumpseconds);
 
 /**
-  * Writes the ascii header for a visibility point in a DiFX format output file
+  * Appends the ascii header for a visibility point to the internal disk output buffer
   */
-  void writeDiFXHeader(ofstream * output, int baselinenum, int dumpmjd, double dumpseconds, int configindex, int sourceindex, int freqindex, const char polproduct[3], int pulsarbin, int flag, float weight, double buvw[3], int filecount);
+  void appendASCIIHeaderBuffered(int baselinenum, int dumpmjd, double dumpseconds, int configindex, int sourceindex, int freqindex, const char polproduct[3], int pulsarbin, int flag, float weight, double buvw[3], int filecount);
 
+/**
+  * Appends the binary header for a visibility point to the internal disk output buffer
+  */
+  void appendSWINHeaderBuffered(int baselinenum, int dumpmjd, double dumpseconds, int configindex, int sourceindex, int freqindex, const char polproduct[3], int pulsarbin, int flag, float weight, double buvw[3], int filecount);
+
+/**
+  * Appends binary data of a visibility or autocorrelation point to the internal disk output buffer
+  */
+  void appendSWINDataBuffered(void * srcdata, size_t numbytes, int filecount);
+
+/**
+ * Flush internal disk output buffer(s) to actual files, append mode
+ * @param multifile Destination of buffered data, true: split over phase centers and bins, false: write all to DIFX_mjd_sec.s0000.b0000
+ */
+ void flushBuffersToDisk(bool multifile);
+
+public:
   Configuration * config;
-  int visID, expermjd, experseconds, currentscan, currentstartseconds, currentstartns, offsetns, offsetnsperintegration, subintsthisintegration, subintns, numvisibilities, numdatastreams, numbaselines, currentsubints, resultlength, currentconfigindex, maxproducts, executeseconds, autocorrwidth, todiskbufferlength, maxfiles;
+  int visID, expermjd, experseconds, currentscan, currentstartseconds, currentstartns, offsetns, offsetnsperintegration, subintsthisintegration, subintns, numvisibilities, numdatastreams, numbaselines, currentsubints, resultlength, currentconfigindex, maxproducts, executeseconds, autocorrwidth, todiskbufferlength, maxfiles, maxbinloop;
   long long estimatedbytes;
   double fftsperintegration, meansubintsperintegration;
   const string * polnames;


### PR DESCRIPTION
General formatting cleanup, slight refactoring (the "buffered" SWIN writing now has append() and flush()).

Adds isEquivalentFrequencyOutput() which encompasses all frequency table entries that are alike to those of isFrequencyOutput(). 

Details: outputted frequencies are always referenced by freq ID from the .input baselines table. However, the visibility-based list of outputted frequency IDs may miss autocorrelations. This happens when autocorrelations use a different freq ID than the visibility record. This is the case when stations differ in Phase Cal tone spacing - then vex2difx introduces two or more "redundant" frequency table entries for the same recorded band(s). These recband frequency IDs are potentially never referenced from the BASELINE table, i.e., the "redundant" freq IDs never occur in the visibility records, but can have autocorrelation data.