### PR TITLE
add new v2d parameter deltaClockAccel

### DIFF
--- a/applications/vex2difx/src/applycorrparams.cpp
+++ b/applications/vex2difx/src/applycorrparams.cpp
@@ -85,7 +85,7 @@ static void applyCorrParams_Clock(VexData *V, const CorrParams &params, unsigned
 			{
 				V->setClock(A->name, antSetup->clock);
 			}
-			V->adjustClock(A->name, antSetup->deltaClock, antSetup->deltaClockRate);
+			V->adjustClock(A->name, antSetup->deltaClock, antSetup->deltaClockRate, antSetup->deltaClockAccel);
 
 			if(!antSetup->difxName.empty())
 			{

--- a/applications/vex2difx/src/corrparams.cpp
+++ b/applications/vex2difx/src/corrparams.cpp
@@ -1174,6 +1174,7 @@ AntennaSetup::AntennaSetup(const std::string &name) : vexName(name), defaultData
 	axisOffset = AXIS_OFFSET_NOT_SET;
 	deltaClock = 0.0;
 	deltaClockRate = 0.0;
+	deltaClockAccel = 0.0;
 	clock.mjdStart = -1e9;
 	clockorder = 1;
 	phaseCalIntervalMHz = -1;
@@ -1299,6 +1300,15 @@ int AntennaSetup::setkv(const std::string &key, const std::string &value)
 			++nWarn;
 		}
 		deltaClockRate = parseDouble(value) / 1.0e6;	// convert from us/sec to sec/sec
+	}
+	else if(key == "deltaClockAccel")
+	{
+		if(deltaClockAccel != 0.0)
+		{
+			std::cerr << "Warning: antenna " << vexName << " has multiple deltaClockAccel definitions" << std::endl;
+			++nWarn;
+		}
+		deltaClockAccel = parseDouble(value) / 1.0e6;	// convert from us/sec to sec/sec
 	}
 	else if(key == "X" || key == "x")
 	{
@@ -2920,7 +2930,7 @@ int CorrParams::sanityCheck()
 			std::cerr << "Warning: the default antenna's coordinates are set!" << std::endl;
 			++nWarn;
 		}
-		if(a->clock.offset != 0 || a->clock.rate != 0 || a->clock.accel != 0 || a->clock.jerk != 0 || a->clock.offset_epoch != 0 || a->deltaClock != 0 || a->deltaClockRate != 0)
+		if(a->clock.offset != 0 || a->clock.rate != 0 || a->clock.accel != 0 || a->clock.jerk != 0 || a->clock.offset_epoch != 0 || a->deltaClock != 0 || a->deltaClockRate != 0 || a->deltaClockAccel != 0)
 		{
 			std::cerr << "Warning: the default antenna's clock parameters are set!" << std::endl;
 			++nWarn;

--- a/applications/vex2difx/src/corrparams.h
+++ b/applications/vex2difx/src/corrparams.h
@@ -211,6 +211,7 @@ public:
 	VexClock clock;
 	double deltaClock;	// [sec]
 	double deltaClockRate;	// [sec/sec]
+	double deltaClockAccel;	// [sec/sec^2]
 	// flag
 	bool polSwap;		// If true, swap polarizations
 	bool polConvert;	// request change of basis from RL->XY or XY->RL

--- a/applications/vex2difx/vexdatamodel/vex_data.cpp
+++ b/applications/vex2difx/vexdatamodel/vex_data.cpp
@@ -815,7 +815,7 @@ void VexData::setClock(const std::string &antName, const VexClock &clock)
 }
 
 // deltaClock in sec and deltaClockRate in sec/sec
-void VexData::adjustClock(const std::string &antName, double deltaClock, double deltaClockRate)
+void VexData::adjustClock(const std::string &antName, double deltaClock, double deltaClockRate, double deltaClockAccel)
 {
 	for(std::vector<VexAntenna>::iterator it = antennas.begin(); it != antennas.end(); ++it)
 	{
@@ -825,6 +825,7 @@ void VexData::adjustClock(const std::string &antName, double deltaClock, double 
 			{
 				c->offset += deltaClock;	// [sec]
 				c->rate += deltaClockRate;	// [sec/sec]
+				c->accel += deltaClockAccel;	// [sec/sec^2]
 			}
 		}
 	}

--- a/applications/vex2difx/vexdatamodel/vex_data.h
+++ b/applications/vex2difx/vexdatamodel/vex_data.h
@@ -86,7 +86,7 @@ public:
 	void setPhaseCalBase(const std::string &antName, float phaseCalBaseMHz);
 	void selectTones(const std::string &antName, enum ToneSelection selection, double guardBandMHz);
 	void setClock(const std::string &antName, const VexClock &clock);
-	void adjustClock(const std::string &antName, double deltaClock, double deltaClockRate);
+	void adjustClock(const std::string &antName, double deltaClock, double deltaClockRate, double deltaClockAccel);
 	void setTcalFrequency(const std::string &antName, int tcalFrequency);
 	void addExperEvents(std::list<Event> &events) const;
 	void addClockEvents(std::list<Event> &events) const;

--- a/doc/userguide/difx_files.tex
+++ b/doc/userguide/difx_files.tex
@@ -1976,13 +1976,16 @@ Name		& Type		& Units 	& Defaults	& Comments \\
 name		& string	&       	&		& new name to assign to this antenna \\
 polSwap		& bool		&       	& False		& swap the polarizations (i.e., {\tt L} $\Leftrightarrow$ {\tt R}) for this antenna \\
 clockOffset	& float		& us		& vex value	& overrides the clock offset value from the vex file \\
-clockRate	& float		& us/s		& vex value	& overrides the clock offset rate value from the vex file \\
+clockRate	& float		& us/s		& vex value	& overrides the clock rate value from the vex file \\
+clockAccel	& float		& us/s/s	& vex value	& overrides the clock acceleration value from the vex file \\
 clockEpoch	& date		&		& vex value	& overrides the epoch of the clock rate value; must be present \\
 		&		&		&		& present if clockRate or clockOffset parameter is set \\
 deltaClock	& float		& us		& 0.0		& adds to the clock offset (either the vex value or the \\
-		&		&		&		& clockOffset above  \\
+		&		&		&		& clockOffset above)  \\
 deltaClockRate	& float		& us/s		& 0.0		& adds to the clock rate (either the vex value or the \\
-		&		&		&		& clockRate above \\
+		&		&		&		& clockRate above) \\
+deltaClockAccel	& float		& us/s/s	& 0.0		& adds to the clock acceleration (either the vex value or the \\
+		&		&		&		& clockAccel above) \\
 X		& float		& m		& vex value	& change the X coordinate of the antenna location \\
 Y		& float		& m		& vex value	& change the Y coordinate of the antenna location \\
 Z		& float		& m		& vex value	& change the Z coordinate of the antenna location \\


### PR DESCRIPTION
Extends v2d by the new parameter "deltaClockAccel", analogous to "deltaClock" and "deltaClockRate".

Updates the User Guide.

The new parameter is useful for correlating VLBI stations that have an undisciplined crystal oscillator reference with poor long-term stability, and for a DiFX correlation setup that is based on still prevalent VEX version 1.5 files where the $CLOCK section does support delay and rate terms but does not allow entering higher order terms.