### PR TITLE
PCAL file: extend MJD and IntTime from 7 to 11 decimal digits

### DIFF
--- a/mpifxcorr/src/visibility.cpp
+++ b/mpifxcorr/src/visibility.cpp
@@ -1001,7 +1001,7 @@ The four columns are:
     {
       nonzero = false;
       // write the header string
-      sprintf(pcalstr, "%s %13.7f %9.7f %d %d %d",
+      sprintf(pcalstr, "%s %17.11f %13.11f %d %d %d",
               config->getDStationName(currentconfigindex, i).c_str(), pcalmjd,
               config->getIntTime(currentconfigindex)/86400.0, i,
               config->getDNumRecordedBands(currentconfigindex, i),


### PR DESCRIPTION
Axel Nothnagel reported that for tInt=0.8192, the `*.difx/PCAL_*` files have MJD values spaced by 0.8208 or 0.8122 seconds. 

Similarly, the integration time in the PCAL file is printed as "0.0000095" days. This translates to 0.8208 seconds.

Both rounding errors are due to insufficient decimal digits in the MJD and IntTime columns.

Expanding that from 7 to 11 digits (patch here) is sufficient to represent a 0.8192-second spacing.

Most likely a cosmetic improvement. The extra digits in the timestamps make no difference in a difx2fits nor difx2mark4 conversion. In HOPS fringe fits there is a tiny difference in fringe amplitude and fringe SNR, at a level of ~1/1000, seems small enough to deem insignificant. But I'll ask Bonn geodetic correlation folks to try out and double check... 
