### PR TITLE
Update of Intel IPP include paths + removed invalid free-statement

### DIFF
--- a/applications/difx2fits/src/fitsAN.c
+++ b/applications/difx2fits/src/fitsAN.c
@@ -91,8 +91,6 @@ const DifxInput *DifxInput2FitsAN(const DifxInput *D, struct fits_keywords *p_fi
 	fitsbuf = (char *)calloc(nRowBytes, 1);
 	if(fitsbuf == 0)
 	{
-		free(dsIds);
-
 		return 0;
 	}
 	

--- a/applications/difx_monitor/mon3d.c
+++ b/applications/difx_monitor/mon3d.c
@@ -33,7 +33,7 @@
 #define USEIPP
 
 #ifdef USEIPP
-#include <ippi.h>
+#include <ipp/ippi.h>
 #define FCMALLOC(x) ippsMalloc_32fc(x)
 #define FMALLOC(x) ippsMalloc_32f(x)
 #define FREE(x) ippsFree(x)

--- a/applications/difx_monitor/monserver.h
+++ b/applications/difx_monitor/monserver.h
@@ -21,7 +21,7 @@
 #include <stdint.h>
 
 #include <configuration.h>
-#include <ipps.h>
+#include <ipp/ipps.h>
 
 using std::string;
 

--- a/genipppc
+++ b/genipppc
@@ -33,7 +33,7 @@ def getippversion(path):
         if isfile(ippheader):
             path += '/composerxe'
     if not isfile(ippheader):
-        ippheader = path+'/oneapi/ipp/latest/include/ippversion.h'
+        ippheader = path+'/oneapi/ipp/latest/include/ipp/ippversion.h'
         if isfile(ippheader):
             path += '/oneapi/ipp/latest/'
     if not isfile(ippheader):

--- a/libraries/vdifio/utils/generateVDIF.c
+++ b/libraries/vdifio/utils/generateVDIF.c
@@ -41,8 +41,8 @@
 
 
 #ifdef USEIPP
-#include <ippcore.h>
-#include <ipps.h>
+#include <ipp/ippcore.h>
+#include <ipp/ipps.h>
 
 #define DEFAULTTAP 128
 

--- a/libraries/vdifio/utils/vdifLinear2circular.c
+++ b/libraries/vdifio/utils/vdifLinear2circular.c
@@ -39,8 +39,8 @@
 #include "vdifio.h"
 #include "config.h"
 
-#include <ippcore.h>
-#include <ipps.h>
+#include <ipp/ippcore.h>
+#include <ipp/ipps.h>
 
 
 #define IPPMALLOC(var,type,n)                                  \

--- a/libraries/vdifio/utils/vdifSwapSideband.c
+++ b/libraries/vdifio/utils/vdifSwapSideband.c
@@ -38,8 +38,8 @@
 #include "config.h"
 
 #if HAVE_IPP
-#include <ippcore.h>
-#include <ipps.h>
+#include <ipp/ippcore.h>
+#include <ipp/ipps.h>
 
 
 #define IPPMALLOC(var,type,n)                                  \

--- a/mpifxcorr/src/architecture.h.gpu.in
+++ b/mpifxcorr/src/architecture.h.gpu.in
@@ -62,9 +62,9 @@
 
 //set up the function mapping for the intel architecture
 #if(ARCH == INTEL)
-#include <ipps.h>
-#include <ippvm.h>
-#include <ippcore.h>
+#include <ipp/ipps.h>
+#include <ipp/ippvm.h>
+#include <ipp/ippcore.h>
 
 //start with the data types
 #define u8                       Ipp8u

--- a/mpifxcorr/src/architecture.h.in
+++ b/mpifxcorr/src/architecture.h.in
@@ -61,10 +61,10 @@
 
 //set up the function mapping for the intel architecture
 #if(ARCH == INTEL)
-#include <ipps.h>
-#include <ippvm.h>
-#include <ippcore.h>
-#include <ippversion.h>
+#include <ipp/ipps.h>
+#include <ipp/ippvm.h>
+#include <ipp/ippcore.h>
+#include <ipp/ippversion.h>
 
 #ifdef IPP9
 #define IPP_9_API

--- a/utilities/fringe_find/fringe_find.cpp
+++ b/utilities/fringe_find/fringe_find.cpp
@@ -6,8 +6,8 @@
 #include <cstdlib>
 #include <string>
 #include <cmath>
-#include <ipps.h>
-#include <ippcore.h>
+#include <ipp/ipps.h>
+#include <ipp/ippcore.h>
 
 static const float SIGMA_LIMIT = 4.0;
 

--- a/utilities/fringe_find/fringe_plotDiFX.cpp
+++ b/utilities/fringe_find/fringe_plotDiFX.cpp
@@ -5,7 +5,7 @@
 #include <fstream>
 #include <vector>
 #include <math.h>
-#include <ipps.h>
+#include <ipp/ipps.h>
 #include <cmath>
 #include "configuration.h"
 


### PR DESCRIPTION
Tested for compile OK against Intel compiler suite version 2021.2.0 and IPP version 2021.12.0.