### PR TITLE
make outputband target freq chosen for LSB/USB correlations consistent with the DiFX-2.5/2.6 choice of USB (instead of LSB)

### DIFF
--- a/applications/vex2difx/src/autobands.cpp
+++ b/applications/vex2difx/src/autobands.cpp
@@ -761,7 +761,7 @@ void AutoBands::addUserOutputband(const ZoomFreq& band)
  *
  * Once the output band of 'inputfreq' has been determined, looks through
  * the list of frequencies 'allfreqs' and locates a match for that output
- * band. Returns the index of that match is returned.
+ * band. Returns the index of that match.
  *
  * If any of the two search stages fails to locate a frequency, the search
  * is repeated with a sideband flipped band having the same sky coverage.

--- a/applications/vex2difx/src/vex2difx.cpp
+++ b/applications/vex2difx/src/vex2difx.cpp
@@ -1161,7 +1161,7 @@ static double populateBaselineTable(DifxInput *D, const CorrParams *P, const Cor
 								}
 								bl->nPolProd[nFreq] = nPol;
 
-								if(D->freq[destFreqId].sideband == 'L' && D->freq[destFreqId2].sideband == 'U' && destFreqId2 >= 0)
+								if(destFreqId2 >= 0 && D->freq[destFreqId].sideband == 'L' && D->freq[destFreqId2].sideband == 'U')
 								{
 									destFreqId = destFreqId2;
 								}
@@ -1308,7 +1308,7 @@ static double populateBaselineTable(DifxInput *D, const CorrParams *P, const Cor
 								}
 								bl->nPolProd[nFreq] = nPol;
 
-								if(D->freq[destFreqId].sideband == 'L' && D->freq[destFreqId2].sideband == 'U' && destFreqId2 >= 0)
+								if(destFreqId2 >= 0 && D->freq[destFreqId].sideband == 'L' && D->freq[destFreqId2].sideband == 'U')
 								{
 									destFreqId = destFreqId2;
 								}

--- a/applications/vex2difx/src/vex2difx.cpp
+++ b/applications/vex2difx/src/vex2difx.cpp
@@ -954,6 +954,11 @@ static double populateBaselineTable(DifxInput *D, const CorrParams *P, const Cor
 			// Here we disable "normal" autocorrelations and instead construct autocorrs as baselines
 			// This allows us to grab cross-hand autocorrs when the polarisations are in different baselines
 
+			// The sideband convention for the cross product of the two bands selected above is:
+			// - LSB/LSB produces an LSB visibility
+			// - USB/USB produces an USB visibility
+			// - mixed-sideband (LSB/USB, USB/LSB) produce an USB visibility
+
 			int enda1 = D->nAntenna-1;
 			if(P->exhaustiveAutocorrs)
 			{
@@ -2565,7 +2570,7 @@ static int writeJob(const Job& J, const VexData *V, const CorrParams *P, const s
 									blockedfreqids[dd->antennaId].insert(dd->recFreqId[parentFreqIndices[nZoom]]);
 								}
 //Corner case BUG: if an LSB-flipping-only zoom *actually* is output, i.e. zoom equal to output,
-//_but_ output fqId differs due to bookkeeping from zoom fqId index, we incorrectly block the LSB-flip...
+//_but_ output fqId differs due to PCal-related bookkeeping from zoom fqId index, we incorrectly block the LSB-flip...
 //Commenting out for now:
 //								if(dd->zoomFreqId[nZoom] != dd->zoomFreqDestId[nZoom])
 //								{

--- a/mpifxcorr/src/configuration.cpp
+++ b/mpifxcorr/src/configuration.cpp
@@ -1988,29 +1988,6 @@ bool Configuration::processFreqTable(istream * input)
     {
       getinputline(input, &line, "PHASE CAL ");
     }
-    freqtable[i].matchingwiderbandindex = -1;
-    freqtable[i].matchingwiderbandoffset = -1;
-  }
-  //now look for matching wider bands
-  for(int i=freqtablelength-1;i>0;i--)
-  {
-    double f1chanwidth = freqtable[i].bandwidth/freqtable[i].numchannels;
-    double f1loweredge = freqtable[i].bandedgefreq;
-    if (freqtable[i].lowersideband)
-      f1loweredge -= freqtable[i].bandwidth;
-    for(int j=i-1;j>=0;j--)
-    {
-      double f2chanwidth = freqtable[j].bandwidth/freqtable[j].numchannels;
-      double f2loweredge = freqtable[j].bandedgefreq;
-      if (freqtable[j].lowersideband)
-        f2loweredge -= freqtable[j].bandwidth;
-      if((i != j) && (f1chanwidth == f2chanwidth) && (f1loweredge < f2loweredge) &&
-          (f1loweredge + freqtable[i].bandwidth > f2loweredge + freqtable[j].bandwidth))
-      {
-        freqtable[j].matchingwiderbandindex = i;
-        freqtable[j].matchingwiderbandoffset = int(((f2loweredge-f1loweredge)/freqtable[i].bandwidth)*freqtable[i].numchannels + 0.5);
-      }
-    }
   }
   freqread = true;
   return true;
@@ -2462,6 +2439,7 @@ bool Configuration::populateResultLengths()
           vector<int> inputfreqs = getSortedInputfreqsOfTargetfreq(c, i);
           // concatenate a complete output data region to the flat results array
           configs[c].coreresultbaselineoffset[i] = new int[numbaselines]();
+          std::fill_n(configs[c].coreresultbaselineoffset[i], numbaselines, -1);
           for(int j=0;j<numbaselines;j++)
           {
             if(!isFrequencyOutput(c,j,i))

--- a/mpifxcorr/src/configuration.cpp
+++ b/mpifxcorr/src/configuration.cpp
@@ -1016,7 +1016,7 @@ Configuration::sectionheader Configuration::getSectionHeader(istream * input)
 
 bool Configuration::processBaselineTable(istream * input)
 {
-  int tempint, dsband, findex, matchfindex;
+  int tempint, dsband;
   int ** tempintptr;
   string line;
   datastreamdata dsdata;
@@ -1113,41 +1113,33 @@ bool Configuration::processBaselineTable(istream * input)
     for(int i=0;i<baselinetablelength;i++)
     {
       const baselinedata& bldata = baselinetable[i];
-      for(int j=0;j<baselinetable[i].numfreqs;j++)
+      for(int j=0;j<bldata.numfreqs;j++)
       {
-        if(bldata.freqtableindices[j] == f) //its a match - check the other datastream for USB
+        int f1index, f2index, foutindex;
+        foutindex = baselinetable[i].targetfreqtableindices[j];
+        dsdata = datastreamtable[bldata.datastream1index];
+        dsband = bldata.datastream1bandindex[j][0];
+        if(dsband >= dsdata.numrecordedbands) //it is a zoom band
+          f1index = dsdata.zoomfreqtableindices[dsdata.zoombandlocalfreqindices[dsband-dsdata.numrecordedbands]];
+        else
+          f1index = dsdata.recordedfreqtableindices[dsdata.recordedbandlocalfreqindices[dsband]];
+        dsdata = datastreamtable[bldata.datastream2index];
+        dsband = bldata.datastream2bandindex[j][0];
+        if(dsband >= dsdata.numrecordedbands) //it is a zoom band
+          f2index = dsdata.zoomfreqtableindices[dsdata.zoombandlocalfreqindices[dsband-dsdata.numrecordedbands]];
+        else
+          f2index = dsdata.recordedfreqtableindices[dsdata.recordedbandlocalfreqindices[dsband]];
+        if(f1index == f || f2index == f) //its a match - check whether one of datastreams is USB
         {
-          dsdata = datastreamtable[bldata.datastream2index];
-          dsband = bldata.datastream2bandindex[j][0];
-          if(dsband >= dsdata.numrecordedbands) //it is a zoom band
-            findex = dsdata.zoomfreqtableindices[dsdata.zoombandlocalfreqindices[dsband-dsdata.numrecordedbands]];
-          else
-            findex = dsdata.recordedfreqtableindices[dsdata.recordedbandlocalfreqindices[dsband]];
-          if(!freqtable[findex].lowersideband)
+          if(freqtable[f1index].lowersideband != freqtable[f2index].lowersideband)
           {
-            //ahah! A cross LSB/USB.  Will need to change so the freqindex used is the USB
-            freqtable[f].correlatedagainstupper = true;
-          }
-        }
-      }
-    }
-    if(freqtable[f].correlatedagainstupper) //need to alter all freqindices to be the equivalent USB
-    {
-      matchfindex = 0;
-      //first find the matching USB freq
-      for(int i=0;i<freqtablelength;i++)
-      {
-        if(!freqtable[i].lowersideband && fabs(freqtable[f].bandwidth - freqtable[i].bandwidth) < Mode::TINY && fabs(freqtable[f].bandedgefreq - freqtable[f].bandwidth - freqtable[i].bandedgefreq) < Mode::TINY) //match
-          matchfindex = i;
-      }
-      for(int i=0;i<baselinetablelength;i++)
-      {
-        const baselinedata& bldata = baselinetable[i];
-        for(int j=0;j<baselinetable[i].numfreqs;j++)
-        {
-          if(bldata.freqtableindices[j] == f) //this baseline had referred to the LSB - replace with the USB freqindex
-          {
-            bldata.freqtableindices[j] = matchfindex;
+            //ahah! A cross LSB/USB. For consistency with DiFX-2.5/2.6 verify destination of LSB/USB is USB; LSB/LSB stays LSB
+            if(freqtable[f1index].lowersideband)
+              freqtable[f1index].correlatedagainstupper = true;
+            else
+              freqtable[f2index].correlatedagainstupper = true;
+            if(freqtable[foutindex].lowersideband)
+              cerror << startl << "Baseline " << i << " product " << j << " of DS " << bldata.datastream1index << " x " << bldata.datastream2index << " is mixed USB/LSB but .input assigns LSB freqId " << foutindex << " instead of an USB freqId" << endl;
           }
         }
       }

--- a/mpifxcorr/src/configuration.h
+++ b/mpifxcorr/src/configuration.h
@@ -136,7 +136,12 @@ public:
   inline int getCompleteStrideLength(int configindex, int freqindex) const { return configs[configindex].completestridelength[freqindex]; }
   inline int getThreadResultFreqOffset(int configindex, int freqindex) const { return configs[configindex].threadresultfreqoffset[freqindex]; }
   inline int getThreadResultBaselineOffset(int configindex, int freqindex, int configbaselineindex) const { return configs[configindex].threadresultbaselineoffset[freqindex][configbaselineindex]; }
-  inline int getCoreResultBaselineOffset(int configindex, int freqindex, int configbaselineindex) const { return configs[configindex].coreresultbaselineoffset[freqindex][configbaselineindex]; }
+  inline int getCoreResultBaselineOffset(int configindex, int freqindex, int configbaselineindex) const {
+    if (configs[configindex].coreresultbaselineoffset[freqindex] != NULL)
+      return configs[configindex].coreresultbaselineoffset[freqindex][configbaselineindex];
+    else
+      return -1;
+  }
   inline int getCoreResultBWeightOffset(int configindex, int freqindex, int configbaselineindex) const { return configs[configindex].coreresultbweightoffset[freqindex][configbaselineindex]; }
   inline int getCoreResultBShiftDecorrOffset(int configindex, int freqindex, int configbaselineindex) const { return configs[configindex].coreresultbshiftdecorroffset[freqindex][configbaselineindex]; }
   inline int getCoreResultAutocorrOffset(int configindex, int configdatastreamindex) const { return configs[configindex].coreresultautocorroffset[configdatastreamindex]; }

--- a/mpifxcorr/src/configuration.h
+++ b/mpifxcorr/src/configuration.h
@@ -346,8 +346,6 @@ public:
   inline bool getFreqTableCorrelatedAgainstUpper(int index) const {return freqtable[index].correlatedagainstupper; }
   inline int getFNumChannels(int index) const { return freqtable[index].numchannels; }
   inline int getFChannelsToAverage(int index) const { return freqtable[index].channelstoaverage; }
-  inline int getFMatchingWiderBandIndex(int index) const { return freqtable[index].matchingwiderbandindex; }
-  inline int getFMatchingWiderBandOffset(int index) const { return freqtable[index].matchingwiderbandoffset; }
   inline bool isFrequencyUsed(int configindex, int freqindex) const
     { return configs[configindex].frequsedbysomebaseline[freqindex]; }
   inline bool isEquivalentFrequencyUsed(int configindex, int freqindex) const
@@ -780,8 +778,6 @@ private:
     int channelstoaverage;
     int oversamplefactor;
     int decimationfactor;
-    int matchingwiderbandindex;
-    int matchingwiderbandoffset;
     string rxName;  // an optional name for the receiver producing this channel
     friend bool operator>(const struct freqdata_t&, const struct freqdata_t&);
     double bandlowedgefreq() const { return (!lowersideband) ? bandedgefreq : bandedgefreq-bandwidth; }

--- a/mpifxcorr/src/configuration.h
+++ b/mpifxcorr/src/configuration.h
@@ -782,8 +782,10 @@ private:
     friend bool operator>(const struct freqdata_t&, const struct freqdata_t&);
     double bandlowedgefreq() const { return (!lowersideband) ? bandedgefreq : bandedgefreq-bandwidth; }
     int npcalsout; // not used by mpifxcorr, but used to quash a warning
+    ostream& printfreq(ostream& os) const;
   } freqdata;
   friend bool operator>(const struct Configuration::freqdata_t&, const struct Configuration::freqdata_t&);
+  friend ostream& operator<<(ostream&, Configuration::freqdata_t&);
 
   ///Storage struct for data from the baseline table of the input file
   typedef struct baselinedata_t {

--- a/mpifxcorr/src/core.cpp
+++ b/mpifxcorr/src/core.cpp
@@ -1726,6 +1726,8 @@ void Core::uvshiftAndAverageBaselineFreq(int index, int threadid, double nsoffse
 
   //get index into procslot::results[<out>] to concatenate spectra of phase centers, bins, and polzns there
   coreindex = config->getCoreResultBaselineOffset(procslots[index].configindex, freqindex, baseline);
+  if(coreindex < 0)
+    csevere << startl << "Baseline " << baseline << " input freqId " << freqindex << " with destination freqId " << targetfreqindex << " is not mapped to any Core results[] array index!";
 
   //collect spectra data from threadcrosscorrs etc, do the multi-phasecenter rotation (if necessary), spectral averaging (if necessary) and concatenation to Core procslot::results[]
   for(int s=0;s<model->getNumPhaseCentres(procslots[index].offsets[0]);s++)

--- a/mpifxcorr/src/visibility.cpp
+++ b/mpifxcorr/src/visibility.cpp
@@ -503,6 +503,8 @@ void Visibility::writedata()
       freqindex = config->getBFreqIndex(currentconfigindex, i, j);
       targetfreqindex = config->getBTargetFreqIndex(currentconfigindex, i, j);
       coreindex = config->getCoreResultBaselineOffset(currentconfigindex, freqindex, i);
+      if(coreindex < 0)
+        csevere << startl << "Baseline " << i << " input freqId " << freqindex << " with destination freqId " << targetfreqindex << " is not mapped to any location in the output data array!" << endl;
       freqchannels = config->getFNumChannels(freqindex)/config->getFChannelsToAverage(freqindex);
       targetfreqchannels = config->getFNumChannels(targetfreqindex)/config->getFChannelsToAverage(targetfreqindex);
       paddingchannels = config->getFChannelsToAverage(freqindex) - config->getFNumChannels(freqindex) % config->getFChannelsToAverage(freqindex);
@@ -844,11 +846,12 @@ void Visibility::writeSWIN(int dumpmjd, double dumpseconds)
 
       // source data location and size
       coreindex = config->getCoreResultBaselineOffset(currentconfigindex, freqindex, i);
+      if(coreindex < 0)
+        csevere << startl << "Error finding SWIN data to store for baseline " << i << ", output freqId " << freqindex << " was not associated with any section of result data array!" << endl;
       resultindex = config->getCoreResultBaselineOffset(currentconfigindex, freqindex, i); // to print out comparison 'coreindex+coreoffset' vs 'resultindex, resultindex+=freqchannels'
       freqchannels = config->getFNumChannels(freqindex)/config->getFChannelsToAverage(freqindex);
-      if(config->getFNumChannels(freqindex) % config->getFChannelsToAverage(freqindex) != 0) {
-       cout << "visbility.cpp " << __LINE__ << " ERROR: outputband nch " << config->getFNumChannels(freqindex) << " not divisible by " << config->getFChannelsToAverage(freqindex) << endl;
-      }
+      if(config->getFNumChannels(freqindex) % config->getFChannelsToAverage(freqindex) != 0)
+        csevere << startl << "visbility.cpp " << __LINE__ << " ERROR: outputband nch " << config->getFNumChannels(freqindex) << " not divisible by " << config->getFChannelsToAverage(freqindex) << endl;
       numpolproducts = config->getBNumPolProducts(currentconfigindex, i, baselinefreqindex);
 
       filecount = 0;

--- a/utilities/vis2screen/printDiFXInput.py
+++ b/utilities/vis2screen/printDiFXInput.py
@@ -175,17 +175,11 @@ def printDiFXInput(basename,opts,indent=2,version=2.6):
 				else:
 					dsfreq1,tmp = getFreqPolOfBand(ds1,min(bl_bands_1))
 					dsfreq2,tmp = getFreqPolOfBand(ds2,min(bl_bands_2))
-					if not cfg.freqs[dsfreq1].lsb:
-						destfreq = dsfreq1
-					elif not cfg.freqs[dsfreq2].lsb:
+					destfreq = dsfreq1
+					if not cfg.freqs[dsfreq2].lsb:
+						# DiFX-2.5/2.6: when DS1 x DS2 is mixed-sideband (LSB/USB) use the USB freq ID,
+						# while LSB/LSB retains the first LSB freq ID, and USB/USB the first USB freq ID.
 						destfreq = dsfreq2
-					else:
-						# look up first USB-equivalent freq if any
-						destfreq = dsfreq1
-						for altfq in cfg.freqs:
-							if (not altfq.lsb) and altfq.low_edge() == cfg.freqs[dsfreq1].low_edge() and altfq.bandwidth == cfg.freqs[dsfreq1].bandwidth:
-								destfreq = cfg.freqs.index(altfq)
-								break
 				if destfreq not in baseline_outputfreq_members:
 					baseline_outputfreq_members[destfreq] = []
 				all_dest_fqs.append(destfreq)
@@ -201,10 +195,11 @@ def printDiFXInput(basename,opts,indent=2,version=2.6):
 					fq2,pol2 = getFreqPolOfBand(ds2,bl_band_2)
 					sfq1 = cfg.freqs[fq1].str().strip()
 					sfq2 = cfg.freqs[fq2].str().strip()
+					sfqdst = cfg.freqs[destfreq].str().strip()
 					fqtype1, fqtype2 = 'rec ', 'rec '
 					if bl_band_1 >= ds1.nrecband: fqtype1 = 'zoom'
 					if bl_band_2 >= ds2.nrecband: fqtype2 = 'zoom'
-					print((" "*3*indent) + "pols %s%s freqs %s x %s" % (pol1,pol2,sfq1,sfq2))
+					print((" "*3*indent) + "pols %s%s freqs %s x %s -> %s" % (pol1,pol2,sfq1,sfq2,sfqdst))
 					if opts.verbosity >= 1:
 						print((" "*3*indent) + "%s %2d x %s %2d -> fq %2d x %2d -> outFq %d" % (fqtype1,bl_band_1,fqtype2,bl_band_2, fq1,fq2,destfreq))
 
@@ -212,13 +207,13 @@ def printDiFXInput(basename,opts,indent=2,version=2.6):
 					if b.version >= 2.7:
 						dest_lo, dest_hi = cfg.freqs[destfreq].low_edge(), cfg.freqs[destfreq].high_edge()
 						if cfg.freqs[fq1].low_edge() < dest_lo:
-							print((" "*3*indent) + "WARNING: fq %d begins %.6f MHz below outFq %d!" % (fq1, dest_lo-cfg.freqs[fq1].low_edge(), destfreq))
+							print((" "*3*indent) + "WARNING: 1st antenna fq %d begins %.6f MHz below outFq %d!" % (fq1, dest_lo-cfg.freqs[fq1].low_edge(), destfreq))
 						if cfg.freqs[fq2].low_edge() < dest_lo:
-							print((" "*3*indent) + "WARNING: fq %d begins %.6f MHz below outFq %d!" % (fq2, dest_lo-cfg.freqs[fq2].low_edge(), destfreq))						
+							print((" "*3*indent) + "WARNING: 2nd antenna fq %d begins %.6f MHz below outFq %d!" % (fq2, dest_lo-cfg.freqs[fq2].low_edge(), destfreq))						
 						if cfg.freqs[fq1].high_edge() > dest_hi:
-							print((" "*3*indent) + "WARNING: fq %d extends %.6f MHz past outFq %d!" % (fq1, cfg.freqs[fq1].high_edge()-dest_hi, destfreq))
+							print((" "*3*indent) + "WARNING: 1st antenna fq %d extends %.6f MHz past outFq %d!" % (fq1, cfg.freqs[fq1].high_edge()-dest_hi, destfreq))
 						if cfg.freqs[fq2].high_edge() > dest_hi:
-							print((" "*3*indent) + "WARNING: fq %d extends %.6f MHz past outFq %d!" % (fq2, cfg.freqs[fq2].high_edge()-dest_hi, destfreq))
+							print((" "*3*indent) + "WARNING: 2nd antenna fq %d extends %.6f MHz past outFq %d!" % (fq2, cfg.freqs[fq2].high_edge()-dest_hi, destfreq))
 						
 		print("")
 


### PR DESCRIPTION
In DiFX-2.8 the target frequency id of a baseline table entry is chosen by vex2difx. Its choice is explicitly stored in the .input file, and mpifxcorr follows that setting.

By default, the target frequency id was chosen to be either that of the first station/frequency on a baseline, or the id of a wider band to which the baseline table entry contributes a spectrum piece.

Under DiFX-2.5/2.6 that choice of frequency id was done implicitly within mpifxcorr and the same logic was replicated in difx2mark4. For mixed sideband (USB/LSB) products the explicit choice written out by DiFX-2.8 vex2difx turned out to be inconsistent with the earlier versions - while USB/LSB was correctly assigned a USB target freq id, LSB/USB was set to a LSB instead of USB target freq.

This PR has fixes to vex2difx such that a USB output freq is chosen for USB/USB, USB/LSB, as well as LSB/USB correlations. An LSB output is chosen only for LSB/LSB correlations. Consistent again with DiFX-2.5/2.6 behaviour.

The PR applies a similar fix to the Python package parseDiFX. When handed an older .input file that lacks the TARGET FREQ keyword, parseDiFX assumes the preferential choice of USB a target freq, rather than simply taking the freq of the first antenna.

The PR also removes the unused obsolete functions getFMatchingWiderBandIndex()  getFMatchingWiderBandOffset().
