### PR TITLE
Add "difxjobslurm" for speedier worst-case single SLURM alloc 

### DIFF
--- a/mpifxcorr/utils/genmachines.py
+++ b/mpifxcorr/utils/genmachines.py
@@ -53,8 +53,8 @@ except ImportError:
     sys.exit(1)
 
 author  = 'Walter Brisken and Helge Rottmann'
-version = '2.5.0'
-verdate = '20200822'
+version = '2.5.1'
+verdate = '20231124'
 minMachinefileVersion = "1.0"   # cluster definition file must have at least this version
 
 defaultDifxMessagePort = 50200
@@ -447,7 +447,7 @@ def adjustMark6datastreams(datastreams, inputfile, verbose, startTime):
                         i += 1
                         continue
                     # look for antenna in filename
-                    if verbose > 0:
+                    if verbose > 1:
                         print('trying to replace', stream.msn[i], 'with a valid mark6 msn')
                     msnsplit = (stream.msn[i]).split('_')
                     if len(msnsplit) >= 2 and (len(msnsplit[1]) == 2 or len(msnsplit[1]) == 1):
@@ -563,6 +563,10 @@ def getDatastreamsFromInputFile(inputfile, verbose):
 def writethreads(basename, threads):
         """
         Write the threads file to be used by mpifxcor
+
+        Args:
+          basename (str): the basename (including full path) of the difx job
+          threads (int): the number of threads to start on each compute node
         """
         o = open(basename+'threads', 'w')
         o.write('NUMBER OF CORES:    %d\n' % len(threads))
@@ -570,7 +574,7 @@ def writethreads(basename, threads):
                 o.write('%d\n' % t)
         o.close()
 
-def writemachines(basename, hostname, results, datastreams, overheadcores, verbose, dorankfile=False):
+def writemachines(basename, hostname, results, datastreams, overheadcores, verbose, dorankfile=False, datastreamsOnly=False):
         """
         Write machines file to be used by mpirun
         """
@@ -710,7 +714,14 @@ def writemachines(basename, hostname, results, datastreams, overheadcores, verbo
                 
         # write machine file
         o = open(basename+'machines', 'w')
-        
+
+        if datastreamsOnly:
+            for node in dsnodes:
+                o.write('%s\n' % (node))
+            o.close()
+
+            return 0
+
         # head node
         o.write('%s\n' % (hostname))
         
@@ -853,7 +864,7 @@ def run(infile, machinesfile, overheadcores, verbose, dothreads, useDifxDb, dora
                 return 1
 
         t = writemachines(basename, hostname, results, datastreams, overheadcores, verbose, dorankfile)
-        
+
         if len(t) == 0:
                 return 1
 
@@ -861,6 +872,103 @@ def run(infile, machinesfile, overheadcores, verbose, dothreads, useDifxDb, dora
                 writethreads(basename, t)
 
         return 0
+
+def runDatastreamsMerged(inputfiles, machinesfile, verbose, dothreads, useDifxDb):
+        # collect all datastreams
+        datastream_modules = []
+        datastream_module_SNs = []
+
+        datastream_files = []
+        datastream_file_paths = []
+
+        for infile in inputfiles:
+
+                if not infile.endswith('.input'):
+                        infile = infile + '.input'
+
+                datastreams = getDatastreamsFromInputFile(infile, verbose)
+
+                for ds in datastreams:
+
+                        # dsinfo = '%s %s %s %s' % (str(ds.type), str(ds.vsn), str(ds.msn), str(ds.path))
+
+                        if ds.type == 'FILE':
+                                if ds.path not in datastream_file_paths:
+                                        datastream_file_paths.append(ds.path)
+                                        datastream_files.append(ds)
+                        elif ds.type == 'MODULE':
+                                if ds.vsn not in datastream_module_SNs:
+                                        datastream_module_SNs.append(ds.vsn)
+                                        datastream_modules.append(ds)
+                        elif ds.type == 'MARK6':
+                                if str(ds.msn) not in datastream_module_SNs:
+                                        datastream_module_SNs.append(str(ds.msn))
+                                        datastream_modules.append(ds)
+                        else:   
+                                print("Unhandled stream: ", dsinfo)
+
+                if verbose:
+                        print('After %s:' % (str(infile)))
+                        print('  Files   : %s' % (str(datastream_file_paths)))
+                        print('  Modules : %s' % (str(datastream_module_SNs)))
+
+
+        if verbose > 0:
+                print('Jobs had the following data sources:')
+                print('File-based  :', datastream_file_paths)
+                print('Module-based:', datastream_module_SNs)
+
+        ok = True
+        datastreams = datastream_modules + datastream_files
+        results, conflicts, missing, notidle, incomplete = getVsnsByMulticast(10, datastreams, verbose)
+
+        if verbose > 0:
+                print('Found modules:')
+                for r in results:
+                        srchost, msgtype = r[0], r[1]
+                        if msgtype == 'mark6Status':
+                                print('  %-10s : %10s %10s %10s %10s' % (srchost, r[2]['slot1MSN'], r[2]['slot2MSN'], r[2]['slot3MSN'], r[2]['slot4MSN']))
+                        elif msgtype == 'mark6SlotStatus':
+                                print('  %-10s : %10s' % (srchost, r[2]['msn']))
+                        else:   
+                                print('  %-10s : %10s %10s   %s' % (srchost, r[2], r[3], r[4]))
+
+        if len(conflicts) > 0:
+                ok = False
+                print('Module conflicts:')
+                for c in conflicts:
+                        print('  %-10s : %10s %10s' % (c[0], c[1], c[2]))
+
+        if len(missing) > 0:
+                ok = False
+                print('Missing modules:')
+                for m in missing:
+                        slot = "unknown"
+                        if useDifxDb:
+                                child = subprocess.Popen(["getslot", m], stdout=subprocess.PIPE)
+                                (slot, stderr) = child.communicate()
+                        print('  %s (slot = %s )' % (m, slot.strip()))
+
+        if len(notidle) > 0:
+                ok = False
+                print('Modules not ready:')
+                for n in notidle:
+                        print('  %s' % n)
+
+        if len(incomplete) > 0:
+                if args.ignoreIncompleteModules == False:
+                        ok = False
+                print('Incomplete modules:')
+                for i in incomplete:
+                        print('  %s' % i)
+
+        if not ok:
+                print('Something was not okay')
+        else:
+                t = writemachines('io_nodes.', '', results, datastreams, 0, verbose, datastreamsOnly=True)
+
+        return ok
+
 
 def signalHandler(signal, frame):
         print('You pressed Ctrl+C!')
@@ -907,6 +1015,7 @@ if __name__ == "__main__":
         parser.add_argument("-r", "--rankfile", dest="dorankfile", action="store_true", default=False, help="additionally write an OpenMPI rank file")
         parser.add_argument("--ignore-incomplete-module", dest="ignoreIncompleteModules", action="store_true", default=True, help="Proceed even when Mark6 modules are found to be incomplete.")
         parser.add_argument("--nocompute", action="store_true", default=False, help="Do not include compute nodes in the .machines file.")
+        parser.add_argument("--all-datastreams", dest="mergeAllDatastreams", action="store_true", default=False, help="Look up datastream nodes from all DiFX input files; implies --nocompute.")
         parser.add_argument("input",  nargs='+', help= "DiFX inputs file(s)")
         
         args = parser.parse_args()
@@ -916,6 +1025,8 @@ if __name__ == "__main__":
         dothreads = args.dothreads
         useDifxDb = args.usedifxdb
         dorankfile = args.dorankfile
+        if args.mergeAllDatastreams:
+                args.nocompute = True
 
         # assign the cluster definition file
         if len(args.machinesfile) == 0:
@@ -940,7 +1051,7 @@ if __name__ == "__main__":
 
         quit = False
         for f in files:
-                if not isfile(f):
+                if not isfile(f) and not isfile(f+'.input'):
                         print('File %s not found' % f)
                         quit = True
         if quit:
@@ -981,8 +1092,12 @@ if __name__ == "__main__":
         if fail:
             print("ERROR: This version of genmachines requires a cluster defintion file of version > %s. Found version is: %s.%s" % (minMachinefileVersion, major,minor))
             exit(1)
+
+        if args.mergeAllDatastreams:
+                v = runDatastreamsMerged(files, 'io_nodes', verbose, dothreads, useDifxDb)
+        else:
         
-        for file in files:
-                v = run(file, machinesfile, overheadcores, verbose, dothreads, useDifxDb, dorankfile)
-                if v != 0:
-                        exit(v)
+                for file in files:
+                        v = run(file, machinesfile, overheadcores, verbose, dothreads, useDifxDb, dorankfile)
+                        if v != 0:
+                                exit(v)

--- a/sites/MPIfR/misc/difxjobslurm/difxjobslurm
+++ b/sites/MPIfR/misc/difxjobslurm/difxjobslurm
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#===========================================================================
+# Copyright (C) 2021  Max-Planck-Institut für Radioastronomie, Bonn, Germany
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#===========================================================================
+# SVN properties (DO NOT CHANGE)
+#
+# $Id: difxslurm 10832 2022-11-17 14:11:11Z JanWagner $
+# $HeadURL: https://svn.atnf.csiro.au/difx/sites/MPIfR/misc/difxslurm/difxslurm $
+# $LastChangedRevision: 10832 $
+# $Author: JanWagner $
+# $LastChangedDate: 2022-11-17 15:11:11 +0100 (Thu, 17 Nov 2022) $
+#
+#============================================================================
+#
+# Intended to be invoked via DiFX
+#
+# $ startdifx -A difxjobslurm <vlbitrack.joblist>
+#
+# The script inspects the .input files associated with the provided .joblist,
+# determines the full set of all Datastreams (Mark6, files, ...) and their
+# location on the cluster (via gen_io_nodes.py).
+#
+# Uses SLURM to reserve those datastream nodes, as well as a fixed
+# number of compute nodes. Reservation is done with SLURM salloc.
+# The same salloc launches a 2nd stage script, difxjobslurm_stage2.
+#
+# The 2nd stage script determines its SLURM-assigned compute nodes and
+# stores them into the .machine file(s), together with genmachines-assigned
+# datastream nodes.
+#
+# Lastly, the script invokes  startdifx --nomachines <vlbitrack.joblist>
+# i.e. uses the SLURM-assigned nodes, but runs DiFX outside of SLURM,
+# with mpirun rather than srun.
+#
+# The flow is:
+#  startdifx -A difxjobslurm
+#  -> difxjobslurm  : gen_io_nodes.py + salloc
+#    -> difxjobslurm_stage2  :  srun /usr/bin/hostname + genmachines
+#      -> startdifx --nomachines :  mpirun
+#
+#============================================================================
+
+set -m               # for backgrounding 'salloc'
+#set -o xtrace       # for tracing/debugging this bash script
+
+## Specific settings (adjust for your cluster)
+partition=correlator
+computenodecount=30
+computenodetag=compute
+threadspercompute=19
+
+
+## Check args
+jobfile=`realpath $1`
+jobpath=`dirname $jobfile`
+joblist=`basename $jobfile`
+
+argextension=${1##*\.}
+if [[ "$argextension" != "joblist" ]]; then
+	echo "error: unrecognized joblist file extension '$joblist', expected e.g. 'file.joblist'"
+	return 1
+fi
+
+jobs=`tail -n +2 $jobpath/$joblist | cut -d " " -f 1`
+if [[ "$jobs" == "" ]]; then
+	echo "error: could not find any scans in $jobfile"
+	return 1
+fi
+
+if [[ "$DIFXROOT" == "" ]]; then
+	echo "error: DIFXROOT env var is empty '', could not determine DiFX environment"
+	return 1
+fi
+
+
+## Generate io_nodes.dsmachines which is a union set of all recorders
+## required for the correlation of the .joblist scans
+DS_HOSTFILE=`mktemp /tmp/$joblist.all_datastreams.XXXXXX`
+echo
+echo "Gathering list of all datastreams involved in $jobfile"
+cd $jobpath
+$DIFXROOT/bin/gen_io_nodes.py -v $jobs
+mv io_nodes.dsmachines $DS_HOSTFILE
+
+# Convert machine file into comma-separated list suitable for 'salloc'
+ionodelist=`cat $DS_HOSTFILE | grep --no-filename -e "mark6-[0-9]*" -e "mark5fx[0-9]*" -e "io[0-9]*" | sort | uniq | paste -sd","`
+ionodecount=`cat $DS_HOSTFILE | sort | uniq | wc -l`
+
+totalnodecount=$((computenodecount+ionodecount))
+
+echo
+echo "Determined $ionodecount data nodes for SLURM - $ionodelist"
+echo "Using fixed number of $computenodecount compute nodes for SLURM - free node assignment"
+echo
+
+echo "At `date` invoking SLURM to allocate and launch 2nd stage:"
+
+echo salloc -J $joblist \
+        -p correlator --nodes=$ionodecount --nodelist=$ionodelist --overcommit --oversubscribe : \
+        -p correlator --nodes=$computenodecount --constraint=$computenodetag --overcommit --cpus-per-task=$threadspercompute --ntasks-per-node=1 \
+		$DIFXROOT/bin/difxjobslurm_stage2.sh $jobpath/$joblist
+
+salloc -J $joblist \
+        -p correlator --nodes=$ionodecount --nodelist=$ionodelist --overcommit --oversubscribe : \
+        -p correlator --nodes=$computenodecount --constraint=$computenodetag --overcommit --cpus-per-task=$threadspercompute --ntasks-per-node=1 \
+		$DIFXROOT/bin/difxjobslurm_stage2.sh $jobfile

--- a/sites/MPIfR/misc/difxjobslurm/difxjobslurm
+++ b/sites/MPIfR/misc/difxjobslurm/difxjobslurm
@@ -32,7 +32,7 @@
 #
 # The script inspects the .input files associated with the provided .joblist,
 # determines the full set of all Datastreams (Mark6, files, ...) and their
-# location on the cluster (via gen_io_nodes.py).
+# location on the cluster via genmachines.py
 #
 # Uses SLURM to reserve those datastream nodes, as well as a fixed
 # number of compute nodes. Reservation is done with SLURM salloc.
@@ -48,7 +48,7 @@
 #
 # The flow is:
 #  startdifx -A difxjobslurm
-#  -> difxjobslurm  : gen_io_nodes.py + salloc
+#  -> difxjobslurm  : genmachines.py --all-datastreams + salloc
 #    -> difxjobslurm_stage2  :  srun /usr/bin/hostname + genmachines
 #      -> startdifx --nomachines :  mpirun
 #
@@ -98,8 +98,8 @@ DS_HOSTFILE=`mktemp /tmp/$joblist.all_datastreams.XXXXXX`
 echo
 echo "Gathering list of all datastreams involved in $jobfile"
 cd $jobpath
-$DIFXROOT/bin/gen_io_nodes.py -v $jobs
-mv io_nodes.dsmachines $DS_HOSTFILE
+$DIFXROOT/bin/genmachines --nocompute --all-datastreams -v $jobs
+mv io_nodes.machines $DS_HOSTFILE
 
 # Convert machine file into comma-separated list suitable for 'salloc'
 ionodelist=`cat $DS_HOSTFILE | grep --no-filename -e "mark6-[0-9]*" -e "mark5fx[0-9]*" -e "io[0-9]*" | sort | uniq | paste -sd","`

--- a/sites/MPIfR/misc/difxjobslurm/difxjobslurm
+++ b/sites/MPIfR/misc/difxjobslurm/difxjobslurm
@@ -24,6 +24,8 @@
 #
 #============================================================================
 #
+# Correlate an entire .joblist under a single SLUMR reservation.
+#
 # Intended to be invoked via DiFX
 #
 # $ startdifx -A difxjobslurm <vlbitrack.joblist>
@@ -63,6 +65,11 @@ threadspercompute=19
 
 
 ## Check args
+if [[ "$1" == "" || "$1" == "-h" || "$1" == "--help" ]]; then
+	echo "Correlate an entire .joblist under a single SLUMR reservation."
+	echo "Usage: $0 <file.joblist>"
+	exit 0
+fi
 jobfile=`realpath $1`
 jobpath=`dirname $jobfile`
 joblist=`basename $jobfile`
@@ -70,18 +77,18 @@ joblist=`basename $jobfile`
 argextension=${1##*\.}
 if [[ "$argextension" != "joblist" ]]; then
 	echo "error: unrecognized joblist file extension '$joblist', expected e.g. 'file.joblist'"
-	return 1
+	exit 1
 fi
 
 jobs=`tail -n +2 $jobpath/$joblist | cut -d " " -f 1`
 if [[ "$jobs" == "" ]]; then
 	echo "error: could not find any scans in $jobfile"
-	return 1
+	exit 2
 fi
 
 if [[ "$DIFXROOT" == "" ]]; then
 	echo "error: DIFXROOT env var is empty '', could not determine DiFX environment"
-	return 1
+	exit 3
 fi
 
 

--- a/sites/MPIfR/misc/difxjobslurm/difxjobslurm_stage2.sh
+++ b/sites/MPIfR/misc/difxjobslurm/difxjobslurm_stage2.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+jobfile=`realpath $1`
+jobpath=`dirname $jobfile`
+joblist=`basename $jobfile`
+argextension=${1##*\.}
+
+jobs=`tail -n +2 $jobpath/$joblist | cut -d " " -f 1`
+jobscsv=`tail -n +2 $jobpath/$joblist | cut -d " " -f 1 | paste -sd","`
+if [[ "$jobs" == "" ]]; then
+	echo "difxjobslurm_stage2 error: could not find any scans in $jobpath/$joblist"
+	exit 1
+fi
+
+if [[ "$DIFX_VERSION" == "" ]]; then
+    echo "difxjobslurm_stage2 Warning: DIFX_VERSION env var is empty. Trying to correlate anyway..."
+fi
+
+
+echo
+echo "Started difxjobslurm_stage2.sh under difx '$DIFX_VERSION' for $jobfile"
+echo "Processing  $jobscsv"
+echo "under SLURM allocation"
+squeue -j $SLURM_JOBID -p correlator
+
+## Ask SLURM for the names of the assigned compute nodes
+COMPUTE_HOSTFILE=`mktemp /tmp/$joblist.compute.XXXXXX`
+echo "Getting full list of compute node names..."
+srun /usr/bin/true : /usr/bin/hostname -s | sort | uniq > $COMPUTE_HOSTFILE
+ncompute=`cat $COMPUTE_HOSTFILE | wc -l`
+
+if [[ $ncompute -le 2 ]]; then
+	echo "Suspiciosly few compute nodes identified by 'srun', aborting."
+	exit 1
+fi
+
+
+## Now dump the SLURM attachment to keep OpenMPI happy
+unset SLURM_JOBID
+unset SLURM_CLUSTER_NAME
+
+## Handle each scan
+for job in $jobs; do
+
+	echo
+	echo "At `date` switched to handling $job"
+
+	## Generate .machines file (FxManager node + datastream nodes only)
+	echo "Generating initial datastream-only .machines file..."
+	rm -f $job.machines
+	genmachines --nocompute $job.input
+
+	## Append the compute nodes
+	echo "Appending $ncompute compute nodes from ${COMPUTE_HOSTFILE}..."
+	cat $COMPUTE_HOSTFILE >> $job.machines
+
+	## Launch correlation
+	startdifx --nomachines $job.input
+
+done
+
+# rm -f $COMPUTE_HOSTFILE

--- a/sites/MPIfR/misc/difxjobslurm/difxjobslurm_stage2.sh
+++ b/sites/MPIfR/misc/difxjobslurm/difxjobslurm_stage2.sh
@@ -44,6 +44,10 @@ for job in $jobs; do
 
 	echo
 	echo "At `date` switched to handling $job"
+	if compgen -G "$job.difx/DIFX_*" > /dev/null; then
+		echo "   $job.difx/DIFX_* file(s) already exists, skipping this job"
+		continue
+	fi
 
 	## Generate .machines file (FxManager node + datastream nodes only)
 	echo "Generating initial datastream-only .machines file..."


### PR DESCRIPTION
An alternate method for starting mpifxcorr under the SLURM workload manager.

The standard way "startdifx -A difxslurm <job>" works only on single jobs rather than a joblist, it makes a SLURM allocation at the beginning and releases the allocation after completion. The allocate-deallocate-allocate-deallocate-... cycle over a series of jobs can have a high time overhead (especially geodetic VLBI on the Bonn cluster). 

The new "difxjobslurm" script takes a joblist and allocates all resources needed for correlating a whole VLBI track, greedily, under a single SLURM allocation. This drastically cuts the said SLURM overhead, albeit at the expense of slightly higher power consumption.

Additions are largely standalone from the rest of DiFX, except one addition to genmachines that adds a new command line argument.