### PR TITLE
in mpifxcorr package, only link IPP to those executables that need it

### DIFF
--- a/mpifxcorr/configure.ac
+++ b/mpifxcorr/configure.ac
@@ -145,7 +145,12 @@ dnl for Mutex lock in datastream.cpp
 AC_CHECK_LIB(rt, clock_gettime)
 
 CXXFLAGS="${CXXFLAGS} ${M5ACCESS_CFLAGS} ${VDIFIO_CFLAGS} ${MARK6SG_CFLAGS} ${MATH_CFLAGS} ${FFTW3_CFLAGS} ${DIFXMESSAGE_CFLAGS} ${MARK5IPC_CFLAGS} ${CFLAG_QUIET} ${OPENMP_CXXFLAGS} ${DIRLIST_CFLAGS} ${MARK6SG_CFLAGS}"
-LIBS="${M5ACCESS_LIBS} ${VDIFIO_LIBS} ${MARK6SG_LIBS} ${SS_LIBS} ${MATH_LIBS} ${DIFXMESSAGE_LIBS} ${MARK5IPC_LIBS} ${DIRLIST_LIBS} $LIBS"
+
+dnl Note: $MATH_LIBS is not included here.  It is added as needed
+dnl in _LDADD options for binaries that link to libmpifxcorr.
+dnl this allows utilities that don't need IPP not to be linked
+dnl with that library.
+LIBS="${M5ACCESS_LIBS} ${VDIFIO_LIBS} ${MARK6SG_LIBS} ${SS_LIBS} ${DIFXMESSAGE_LIBS} ${MARK5IPC_LIBS} ${DIRLIST_LIBS} $LIBS"
 
 
 dnl **********************************************************

--- a/mpifxcorr/src/Makefile.am
+++ b/mpifxcorr/src/Makefile.am
@@ -18,6 +18,8 @@ else
 mark6_files =
 endif
 
+mpifxcorr_LDADD = ${mathlibs}
+
 bin_PROGRAMS = mpifxcorr neuteredmpifxcorr
 
 mpifxcorr_SOURCES = \
@@ -133,7 +135,7 @@ neuteredmpifxcorr_SOURCES = \
 
 neuteredmpifxcorr_CXXFLAGS = -DNEUTERED_DIFX $(AM_CXXFLAGS)
 
-neuteredmpifxcorr_LDADD = libfxcorr.a
+neuteredmpifxcorr_LDADD = libfxcorr.a ${mathlibs}
 
 # Test programs relocated from ./test/ to ./src/test/ due to automake
 # https://bugs.freedesktop.org/show_bug.cgi?id=69874

--- a/mpifxcorr/utils/Makefile.am
+++ b/mpifxcorr/utils/Makefile.am
@@ -22,9 +22,9 @@ dedisperse_difx_SOURCES = \
 mpispeed_SOURCES = \
 	mpispeed.cpp
 
-checkmpifxcorr_LDADD = ../src/libmpifxcorr.a
+checkmpifxcorr_LDADD = ../src/libmpifxcorr.a ${mathlibs}
 
-dedisperse_difx_LDADD = ../src/libmpifxcorr.a
+dedisperse_difx_LDADD = ../src/libmpifxcorr.a ${mathlibs}
 
 install-exec-hook:
 	mv $(DESTDIR)$(bindir)/genmachines.py $(DESTDIR)$(bindir)/genmachines


### PR DESCRIPTION
Prevent IPP from being linked to programs in the mpifxcorr package that do not need it.