### PR TITLE
Support vanVleck correction for more than 8 bits per sample

### DIFF
--- a/applications/difx2fits/ChangeLog
+++ b/applications/difx2fits/ChangeLog
@@ -25,6 +25,7 @@ Version 3.8.0
 * Sniffer: don't interpolate across scans, even on same source
 * Sniffer: flush last records before program exit
 * --two-pcal-tables option added: Will create one table as prescribed in the .input files and the other containing all of the pulse cal tones. ***experimental***
+* Use vanVleck correction of 1.0 in case of >= 8 bits per sample for both datastreams if an explicit value is not available.
 
 Version 3.7.0
 * Post DiFX-2.6

--- a/applications/difx2fits/src/fitsUV.c
+++ b/applications/difx2fits/src/fitsUV.c
@@ -253,6 +253,12 @@ static double vanVleck(int b1, int b2)
 		}
 	}
 
+	/* If both datastreams use 8 or more bits and the above table does not have an entry, it is reasonabl to assume that 1.0 is close enough */
+	if(b1 >= 8 && b2 >= 8)
+	{
+		return 1.0;
+	}
+
 	return 0.0;	/* effectively an error code */
 }
 


### PR DESCRIPTION
Make a default vanVleck correction of 1.0 (no change) if there is no explicitly calculated value when using 8+ bits per sample on both datastreams