### PR TITLE
refine vex2difx job splitting: ignore antennas unrelated to job

### DIFF
--- a/applications/vex2difx/src/jobgroup.cpp
+++ b/applications/vex2difx/src/jobgroup.cpp
@@ -26,6 +26,13 @@ bool JobGroup::hasScan(const std::string &scanName) const
 	return find(scans.begin(), scans.end(), scanName) != scans.end();
 }
 
+bool JobGroup::hasAntenna(const std::string &antennaName) const
+{
+	return (antennas.find(antennaName) != antennas.end());
+}
+
+// Generate a filtered list of events for internal use,
+// retaining only events related to scans and antennas of this JobGroup
 void JobGroup::genEvents(const std::list<Event> &eventList)
 {
 	for(std::list<Event>::const_iterator it = eventList.begin(); it != eventList.end(); ++it)
@@ -38,7 +45,18 @@ void JobGroup::genEvents(const std::list<Event> &eventList)
 			if(hasScan(it->scan))
 			{
 				events.push_back(*it);
-			}	
+			}
+		}
+		else if(it->eventType == Event::CLOCK_BREAK ||
+			it->eventType == Event::RECORD_START ||
+			it->eventType == Event::RECORD_STOP ||
+			it->eventType == Event::ANTENNA_START ||
+			it->eventType == Event::ANTENNA_STOP)
+		{
+			if(hasAntenna(it->name))
+			{
+				events.push_back(*it);
+			}
 		}
 		else
 		{

--- a/applications/vex2difx/src/jobgroup.h
+++ b/applications/vex2difx/src/jobgroup.h
@@ -23,6 +23,7 @@
 #include <iostream>
 #include <vector>
 #include <list>
+#include <set>
 #include <string>
 #include "job.h"
 #include "event.h"
@@ -32,9 +33,11 @@ class JobGroup : public Interval
 {
 public:
 	std::vector<std::string> scans;
+	std::set<std::string> antennas;
 	std::list<Event> events;
 
 	bool hasScan(const std::string &scanName) const;
+	bool hasAntenna(const std::string &antennaName) const;
 	void genEvents(const std::list<Event> &eventList);
 	void createJobs(std::vector<Job> &jobs, Interval &jobTimeRange, const VexData *V, double minLength, double maxLength, double maxSize) const;
 };

--- a/applications/vex2difx/src/makejobs.cpp
+++ b/applications/vex2difx/src/makejobs.cpp
@@ -79,6 +79,10 @@ static void genJobGroups(std::vector<JobGroup> &JGs, const VexData *V, const Cor
 		JobGroup &JG = JGs.back();
 		JG.scans.push_back(scans.front());
 		JG.setTimeRange(*scan);
+		for(std::map<std::string,Interval>::const_iterator it = scan->stations.begin(); it != scan->stations.end(); ++it)
+		{
+			JG.antennas.insert(it->first);
+		}
 		scans.pop_front();
 
 		const VexScan *scan1 = V->getScanByDefName(JG.scans.back());


### PR DESCRIPTION
Vex2difx behaves suboptimally in a special case of a sub-arrayed VLBI experiment that contains clock breaks.

To illustrate, assume an experiment with:

Scan 1a from 106-0400 till 106-0415 with stations Aa Bb Cc
Scan 1b from 106-0408 till 106-0420 with stations Kk Nn Mm
VEX clock_early break at Kk at 106-0408

For this vex2difx unexpectedly generates 3 jobs - two for scan 1a, one for 1b:

Job 1 spans 106-0400 till 106-0408 with stations Aa Bb Cc
Job 2 spans 106-0408 till 106-0415 with stations Aa Bb Cc
Job 3 spans 106-0408 till 106-0420 with stations Kk Nn Mm

Since Kk with its clock break is not even part of scan 1a, splitting that scan into two jobs feels unnecessary. In fact, it also triggers a problem downstream in difx2mark4 which does not support merging back the data of two jobs into one scan - about half the visibility data (job 2 of scan 1a) are lost to difx2mark4.

It turns out there is already a pre-filtering function in JobGroup that goes through a time series of global VEX "events" (scan start, stop, antenna scan start, stop). It discards events that have nothing to do with scans of the JobGroup.

This minimal patch extends that pre-filtering function.

The pre-filtering now also discards events that have nothing to do with the *antennas* of the JobGroup. 

In the above test case ,vex2difx now generates a more optimal set of jobs:
Job 1 spans 106-0400 till 106-0415 with stations Aa Bb Cc, the unrelated break at Kk is ignored
Job 2 spans 106-0408 till 106-0420 with stations Kk Nn Mm, and with the correct Kk clock
