### PR TITLE
Fix link to CONTRIBUTION.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ See the userguide of DiFX.
 
 Feel free to join us!  [Open an issue](https://github.com/difx/difx/issues/new) or submit PRs is always welcome.
 
-Find more details on [CONTRIBUTION](https://github.com/difx/difx/CONTIBUTION.md) .
+Find more details on [CONTRIBUTION](https://github.com/difx/difx/blob/main/CONTRIBUTION.md) .
 
 
 


### PR DESCRIPTION
Currently this is a deadlink on main pointing to CONTIBUTION.md. Fixing this to CONTRIBUTION.md did not bring up the correct file. 

This change fixes the link.