### PR TITLE
increase d2m4 NVRMAX for EHT VLBI

### DIFF
--- a/applications/difx2mark4/src/difx2mark4.h
+++ b/applications/difx2mark4/src/difx2mark4.h
@@ -32,7 +32,7 @@
 #define MAGLIM 10000.0              // threshold magnitude for vis. rejection
 #define MAX_FPPAIRS 48000           // dimensioned for b-lines x chans x pol_prods
 #define MAX_DFRQ 800                // allowed max number of *DiFX* frequencies
-#define NVRMAX 8000000              // max # of vis records
+#define NVRMAX 98304000             // max # of vis records
 
 // Type 309 records - limits for createType3s.c and write_t3??.c
 #define NPC_TONES 64                // max number of pcal tones in t309 record


### PR DESCRIPTION
Running into scans again where the number of visibility entries in .difx exceeds the hardcoded limit of 8000000 visibility records in difx2mark4. Such scans fail to convert at all.

Increased the limit to 4-pol * 64-antenna * 3000 records * 128 IFs = 98304000. That's 3000 * 0.4 sec AP = 20 minute long scans. With margin since usually <16 antennas and just 32 IFs.

Would be nice to have this in 2.9.0-a as well.