### PR TITLE
Several fixes and improvements in response to unexpected behavior of …

### DIFF
--- a/applications/vex2difx/ChangeLog
+++ b/applications/vex2difx/ChangeLog
@@ -42,7 +42,7 @@ Version 2.99.3
 * in cases where it is known (e.g., vex2-based files) and the same across antennas, populate the "RX NAME" field in the .input file
 * increase maximum project code length to 24 (from 7)
 * Support for output band configuration
-* Note: fanout_def is now required for every data format, even VDIF.  See https://www.atnf.csiro.au/vlbi/dokuwiki/doku.php/difx/formatdef for more info.
+* Note: fanout_def is now required for every data format, even VDIF.  See https://github.com/difx/difx/wiki/formatdef for more info.
 
 Version 2.99.2
 ~~~~~~~~~~~~~~

--- a/applications/vex2difx/README
+++ b/applications/vex2difx/README
@@ -1,10 +1,11 @@
+# vex2difx
 
-Full documentation is at: http://www.atnf.csiro.au/vlbi/dokuwiki/doku.php/difx/vex2difx
-
+Full documentation is at: https://github.com/difx/difx/wiki/vex2difx 
+ 
 Requirements:
 
 vex2difx requires a recent version of difxio available at:
-https://svn.atnf.csiro.au/difx/libraries/difxio/trunk
+https://github.com/difx/difx/tree/main/libraries/difxio
 
 To install from a fresh svn checkout, run the following:
 

--- a/applications/vex2difx/sampledata/c212c-d280.v2d
+++ b/applications/vex2difx/sampledata/c212c-d280.v2d
@@ -1,5 +1,5 @@
 vex = c212c.vex
-# https://www.atnf.csiro.au/vlbi/dokuwiki/doku.php/difx/vex2difx
+# https://github.com/difx/difx/wiki/vex2difx
 singleScan = True
 singleSetup = True
 minSubarray = 2

--- a/applications/vex2difx/src/vex2v2d.cpp
+++ b/applications/vex2difx/src/vex2v2d.cpp
@@ -472,23 +472,36 @@ int main(int argc, char **argv)
 
 			return EXIT_FAILURE;
 		}
-		else if(specRes > 0.0)
+		else if(strstr(argv[a], ".vex") != 0)  
 		{
-			printf("Error: too many non-optional parameters provided.\n\n");
-
-			return EXIT_FAILURE;
-		}
-		else if(vexFile == 0)
-		{
+			if(vexFile != 0)
+			{
+				printf("Error: multiple vex files specified\n\n");
+				return EXIT_FAILURE;
+			}
 			vexFile = argv[a];
 		}
-		else if(tInt <= 0.0)
+		else  
 		{
-			tInt = atof(argv[a]);
-		}
-		else
-		{
-			specRes = atof(argv[a]);
+			if(vexFile == 0)  
+			{
+				printf("Error: vex file must be specified before tInt or specRes\n\n");
+				return EXIT_FAILURE;
+			}
+			
+			if(tInt <= 0.0)  
+			{
+				tInt = atof(argv[a]);
+			}
+			else if(specRes <= 0.0)  
+			{
+				specRes = atof(argv[a]);
+			}
+			else
+			{
+				printf("Error: too many non-optional parameters provided.\n\n");
+				return EXIT_FAILURE;
+			}
 		}
 	}
 
@@ -566,3 +579,4 @@ int main(int argc, char **argv)
 
 	return v;
 }
+


### PR DESCRIPTION
This update is merged into dev and is ready to be pulled into release-2.9.0-a

This branch responds to new behavior in vex2difx when overriding formats.  In 2.9.0, specifying "format" causes the entirety of the format to be reset.  That is, if "format=VDIF/5032", it is assumed that this is now a single-thread format, even if multiple threads were previously defined.  If a partial format change is needed, now the "nBit=", "frameSize=", and "sampling=" can be used.
