### PR TITLE
small fixes to PolConvert python scripting

### DIFF
--- a/applications/polconvert/src/Changelog
+++ b/applications/polconvert/src/Changelog
@@ -1,3 +1,7 @@
+pre-v2.0.8
+- fix for the QA2TABLES env var
+- updated documentation on drivepolconvert.py -q <version>
+
 v2.0.7
 - progress on the merger between CASA and standalone cases
 - argument reconciliation between the two branches (task* and CASA*)

--- a/applications/polconvert/src/PP/drivepolconvert.py
+++ b/applications/polconvert/src/PP/drivepolconvert.py
@@ -244,7 +244,7 @@ def tableSchemeHelp():
         d <label>.calibrated.ms.<Df0|Df0gen>.<APP|ALMA>
         b <label>.concatenated.ms.<bandpass-zphs|bandpassAPP>
         g <label>.concatenated.ms.flux_inf.<APP|ALMA>
-        p <label>.concatenated.ms.phase_int.<APP|ALMA><.XYsmooth>
+        p <label>.concatenated.ms.phase_int.<APP|ALMA>[.XYsmooth]
         x <label>.calibrated.ms.<XY0|XY0kcrs>.<APP|ALMA>
         y <label>.calibrated.ms.Gxyamp.<APP|ALMA>
     
@@ -269,8 +269,8 @@ def tableSchemeHelp():
     the name with -Y; e.g. XY0.APP to XY0kcrs.APP
 
     For data until year 2022 the built-in versions v4 .. v11 are sensible,
-    paired with overrides of '-Y XY0kcrs.APP' and '-B bandpassAPP' if needed.
-    From data from 2022 onwards the ALMA QA2 process has diverged such that
+    paired with overrides of '-Y XY0kcrs.APP' and '-B bandpassAPP' as needed.
+    For data from 2022 onwards the ALMA QA2 process has diverged such that
     the above version schemes are obsolete and incompatible with APP QA2 output,
     despite the READMEs in the APP QA2 deliverable suggesting otherwise.
 

--- a/applications/polconvert/src/PP/drivepolconvert.py
+++ b/applications/polconvert/src/PP/drivepolconvert.py
@@ -234,17 +234,18 @@ def tableSchemeHelp():
     observations, and non-QA2 (solve) mode where a solution is derived
     from one scan and applied to others.
 
-    The first scheme has twelve versions, v0 .. v11 based on the development
-    history.  Currently v4 .. v11 are sensible; the default is v8.  This
-    scheme requires a set of tables (named with the the -l label argument):
+    PolConvert requires a set of tables (named with the the -l label argument):
+
+    Historically these could be described with twelve versions, v0 .. v11,
+    all containing variants of this set of tables:
 
         a <label>.concatenated.ms.ANTENNA
         c <label>.concatenated.ms.calappphase
-        d <label>.calibrated.ms.Df0.<APP|ALMA>
-        b <label>.concatenated.ms.bandpass-zphs
+        d <label>.calibrated.ms.<Df0|Df0gen>.<APP|ALMA>
+        b <label>.concatenated.ms.<bandpass-zphs|bandpassAPP>
         g <label>.concatenated.ms.flux_inf.<APP|ALMA>
         p <label>.concatenated.ms.phase_int.<APP|ALMA><.XYsmooth>
-        x <label>.calibrated.ms.XY0.<APP|ALMA>
+        x <label>.calibrated.ms.<XY0|XY0kcrs>.<APP|ALMA>
         y <label>.calibrated.ms.Gxyamp.<APP|ALMA>
     
     Here APP or ALMA refers to ALMA Phasing Project/System (APP/APS) scans
@@ -264,14 +265,20 @@ def tableSchemeHelp():
     v10 .    .    APP  .    APP  ALMA APP  APP  yes
     v11 .    .    APP  .    APP  APP  APP  ALMA yes
 
-    The second scheme assumes an initial reduction with <TBD.py>.
-
     If an alternate table for the XY0 phase is suggested, you can change
     the name with -Y; e.g. XY0.APP to XY0kcrs.APP
 
-    Finally an environment variable QA2TABLES may be set to a comma-sep
-    list of compete table names (ignoring label, concatenated and calibrated)
-    may be used for any arbitrary set of tables.
+    For data until year 2022 the built-in versions v4 .. v11 are sensible,
+    paired with overrides of '-Y XY0kcrs.APP' and '-B bandpassAPP' if needed.
+    From data from 2022 onwards the ALMA QA2 process has diverged such that
+    the above version schemes are obsolete and incompatible with APP QA2 output,
+    despite the READMEs in the APP QA2 deliverable suggesting otherwise.
+
+    An environment variable QA2TABLES may be set to a comma-separated list of
+    table names (omitting the label, concatenated.ms and calibrated.ms name prefixes)
+    to specify any arbitrary set of tables. For example, for EHT 2022:
+    $ export QA2TABLES="ANTENNA,calappphase,Df0gen.APP,bandpassAPP,flux_inf.APP.OpCorr,phase_int.APP.XYsmooth,XY0kcrs.APP,Gxyamp.APP"
+    $ drivepolconvert.py -q custom -l qa2label <etc>
     '''
     print(story)
 
@@ -338,6 +345,8 @@ def calibrationChecks(o):
     ### if push comes to shove
     else:               # supply via environment variable
         o.qal = os.environ['QA2TABLES'].split(',')
+        o.conlabel = o.label + '.concatenated.ms'
+        o.callabel = o.label + '.calibrated.ms'
     if tbwarn:
         print('\n\n ***You have selected an obsolete set of tables')
         print('Will proceed--but you had better known what you are doing.\n')

--- a/applications/polconvert/src/PP/runpolconvert.py
+++ b/applications/polconvert/src/PP/runpolconvert.py
@@ -56,7 +56,7 @@ try:
     dtermcal = ('%s/%s.'+qa2['d'])%(DiFXout,callabel) # Df0 | Df0gen
     bandpass = ('%s/%s.'+qa2['b'])%(DiFXout,conlabel) # bandpass-zphs | bandpassAPP
     ampgains = ('%s/%s.'+qa2['g'])%(DiFXout,conlabel) # flux_inf.APP
-    phsgains = ('%s/%s.'+qa2['p'])%(DiFXout,conlabel) # phase_int.APP*
+    phsgains = ('%s/%s.'+qa2['p'])%(DiFXout,conlabel) # phase_int.APP[.XYsmooth]
     xyrelphs = ('%s/%s.'+qa2['x'])%(DiFXout,callabel) # XY0.APP or XY0.ALMA | XY0kcrs.APP or XY0kcrs.ALMA
     gxyampli = ('%s/%s.'+qa2['y'])%(DiFXout,callabel) # Gxyamp.APP/Gxyamp.ALMA
     if v4tables:    #production v4

--- a/applications/polconvert/src/PP/runpolconvert.py
+++ b/applications/polconvert/src/PP/runpolconvert.py
@@ -53,11 +53,11 @@ if v4tables is None:
 try:
     aantpath = ('%s/%s.'+qa2['a'])%(DiFXout,conlabel) # ANTENNA
     calapphs = ('%s/%s.'+qa2['c'])%(DiFXout,conlabel) # calappphase
-    dtermcal = ('%s/%s.'+qa2['d'])%(DiFXout,callabel) # Df0
-    bandpass = ('%s/%s.'+qa2['b'])%(DiFXout,conlabel) # bandpass-zphs
+    dtermcal = ('%s/%s.'+qa2['d'])%(DiFXout,callabel) # Df0 | Df0gen
+    bandpass = ('%s/%s.'+qa2['b'])%(DiFXout,conlabel) # bandpass-zphs | bandpassAPP
     ampgains = ('%s/%s.'+qa2['g'])%(DiFXout,conlabel) # flux_inf.APP
     phsgains = ('%s/%s.'+qa2['p'])%(DiFXout,conlabel) # phase_int.APP*
-    xyrelphs = ('%s/%s.'+qa2['x'])%(DiFXout,callabel) # XY0.APP or XY0.ALMA
+    xyrelphs = ('%s/%s.'+qa2['x'])%(DiFXout,callabel) # XY0.APP or XY0.ALMA | XY0kcrs.APP or XY0kcrs.ALMA
     gxyampli = ('%s/%s.'+qa2['y'])%(DiFXout,callabel) # Gxyamp.APP/Gxyamp.ALMA
     if v4tables:    #production v4
         calgains = [aantpath, calapphs, dtermcal,


### PR DESCRIPTION
Needed for polconversion of EHT and GMVA VLBI tracks since year 2022.

Fixes some documentation and the use of the QA2TABLES env var parameter.

Good for 'dev', but would be nice to still get this fix into 'release-2.9.0-a', too.

This PR combines changes from https://github.com/marti-vidal-i/PolConvert/pull/14.

PolConversion of EHT/GMVA 2022+ rely on the calibration data packages provided by the ALMA APP QA2 process. The packages indicate a table-set scheme (usually "v8" or "v9") that exists in PolConvert and which selects specific tables out of a set of several delivered tables. Alas the QA2 process quietly ceased adhering to the schemes since 2022. None of the schemes match the QA2 output. Thus a functional QA2TABLES=\<explicit list of tables\> instead of the QA2-included but incorrect scheme code is needed.

