### PR TITLE
improve handling of overlapped recorded bands in vex2difx AutoBands

### DIFF
--- a/applications/vex2difx/src/autobands.cpp
+++ b/applications/vex2difx/src/autobands.cpp
@@ -37,6 +37,26 @@ template class std::vector<AutoBands::Outputband>;
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+struct freqComparator
+{
+	// Helper for custom sort - std::sort([begin], [end], freqComparator())
+	public: bool operator()(const freq& left, const freq& right) const
+	{
+		return left.fq < right.fq;
+	}
+};
+
+struct bandfreqComparator
+{
+	// Helper for custom sort - std::sort([begin], [end], bandfreqComparator())
+	public: bool operator()(const AutoBands::Band& left, const AutoBands::Band& right) const
+	{
+		return left.min_flow < right.min_flow;
+	}
+};
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
 double AutoBands::Band::bandwidth() const
 {
 	return fhigh - flow;
@@ -98,11 +118,20 @@ bool AutoBands::Outputband::isComplete() const
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
+AutoBands::AutoBands()
+{
+	this->outputbandwidth = -1;
+	this->verbosity = 0;
+	this->permitgaps = false;
+	this->autozoomgranularity = 0;
+}
+
 AutoBands::AutoBands(double outputbandwidth_Hz, int verbosity, bool permitgaps)
 {
 	this->outputbandwidth = outputbandwidth_Hz;
 	this->verbosity = verbosity;
 	this->permitgaps = permitgaps;
+	this->autozoomgranularity = 0;
 	clear();
 }
 
@@ -136,6 +165,19 @@ void AutoBands::setBandwidth(double outputbandwidth_Hz)
 }
 
 /**
+ * Set bandwidth granularity in Hz to use if possbile when generating auto-zooms
+ * that form outputbands.
+ */
+double AutoBands::setAutozoomGranularity(const double& azgranularity_Hz)
+{
+    if (azgranularity_Hz >= 0)
+    {
+        this->autozoomgranularity = azgranularity_Hz;
+		std::cout << "AutoBands::setAutozoomGranularity " << this->autozoomgranularity << " Hz\n";
+    }
+}
+
+/**
  * Add a recorded band if it has not been added for the same antenna Id before
  */
 void AutoBands::addRecbandUnique(const AutoBands::Band& recband)
@@ -156,6 +198,10 @@ void AutoBands::addRecbandUnique(const AutoBands::Band& recband)
 
 	if(!exists)
 	{
+		if(verbosity > 2)
+		{
+			std::cout << "AutoBands::addRecbandUnique(): ant " << recband.antenna << " adding " << recband << "\n";
+		}
 		bands.push_back(recband);
 	}
 }
@@ -166,20 +212,21 @@ void AutoBands::addRecbandUnique(const AutoBands::Band& recband)
 void AutoBands::addRecbands(const std::vector<double>& fstart, const std::vector<double>& fstop, int antId)
 {
 	assert(fstart.size() == fstop.size());
-	if(antId == -1)
-	{
-		antId = Nant;
-	}
+
+	// Zip (fstart,fstop) into a joint vector and addRecbands() it
+	std::vector<freq> freqs;
 	for(unsigned i = 0; i < fstart.size(); i++)
 	{
-		double lo = fstart[i], hi = fstop[i];
+		double lo = fstart[i], hi = fstop[i], bw;
 		if(lo > hi)
 		{
 			std::swap(lo, hi);
 		}
-		addRecbandUnique(AutoBands::Band(lo, hi, antId));
+		bw = hi - lo;
+		freqs.push_back(freq(lo, bw, 'U'));
 	}
-	Nant++;
+
+	this->addRecbands(freqs, antId);
 }
 
 /**
@@ -187,27 +234,71 @@ void AutoBands::addRecbands(const std::vector<double>& fstart, const std::vector
  */
 void AutoBands::addRecbands(const std::vector<freq>& freqs, int antId)
 {
+	if(freqs.empty())
+	{
+		return;
+	}
 	if(antId == -1)
 	{
 		antId = Nant;
 	}
+
+	// Flip frequencies to Upper Sideband
+	std::vector<AutoBands::Band> tidiedfreqs;
 	for(unsigned i = 0; i < freqs.size(); i++)
 	{
-		double lo = freqs[i].fq;
-		double hi = freqs[i].fq + ((freqs[i].sideBand == 'U') ? freqs[i].bw : -freqs[i].bw);
-		if(lo > hi)
+		if(freqs[i].sideBand == 'L')
 		{
-			std::swap(lo, hi);
+			tidiedfreqs.push_back(AutoBands::Band(freqs[i].fq - freqs[i].bw, freqs[i].fq, antId));
 		}
-		addRecbandUnique(AutoBands::Band(lo, hi, antId));
+		else
+		{
+			tidiedfreqs.push_back(AutoBands::Band(freqs[i].fq, freqs[i].fq + freqs[i].bw, antId));
+		}
 	}
+
+	// Sort by frequency and drop duplicates
+	sort(tidiedfreqs.begin(), tidiedfreqs.end(), bandfreqComparator());
+	tidiedfreqs.erase(unique(tidiedfreqs.begin(), tidiedfreqs.end()), tidiedfreqs.end());
+
+	// Detect overlapped bands, replace edges of overlap with mid-point frequency
+	for(unsigned i = 0; i < tidiedfreqs.size() - 1; i++)
+	{
+		double fhi = tidiedfreqs[i].fhigh;
+		if(fhi > tidiedfreqs[i+1].flow)
+		{
+			double overlap_half_bw = (fhi - tidiedfreqs[i+1].flow) / 2;
+			if(verbosity > 2)
+			{
+				std::cout << std::setw(15) << std::setprecision(11)
+					<< "AutoBands::addRecbands(<vector>): trimming overlapped recbands"
+					<< " by " << overlap_half_bw*1e-6 << " MHz of bw and shifting edges"
+					<< " of recband" << i << "_hi:" << fhi*1e-6 << " recband" << i+1 << "_lo:" << tidiedfreqs[i+1].flow*1e-6
+					<< " to joint mid " << (fhi - overlap_half_bw)*1e-6 << " MHz\n";
+			}
+			tidiedfreqs[i].overlapping = true;
+			tidiedfreqs[i+1].overlapping = true;
+			tidiedfreqs[i].fhigh  -= overlap_half_bw;
+			tidiedfreqs[i+1].flow += overlap_half_bw;
+			// tidiedfreqs[i].max_fhigh retains the original high edge of recband
+			// tidiedfreqs[i+1].min_flow retains the original low edge of the other recband
+		}
+	}
+
+
+	// Register the band details
+	for(unsigned i = 0; i < tidiedfreqs.size(); i++)
+	{
+		addRecbandUnique(tidiedfreqs[i]);
+	}
+
 	Nant++;
 }
 
 /**
  * Return the greatest-common-divisor of a list of frequencies
  */
-double AutoBands::getGranularity(const std::vector<double>& args) const
+double AutoBands::computeGranularity(const std::vector<double>& args) const
 {
 	if(args.size() < 1)
 	{
@@ -275,7 +366,7 @@ double AutoBands::autoBandwidth()
  * NB: Ideally we'd check only the set of definitely present antennas (v2d antennas=... + VEX scan antenna
  * list + filelist) since e.g. the most heavily channelized antenna might actually be absent and
  * thus better optimization of auto-zoombands (i.e., a reduction to fewer zooms) might be possible.
- * However, not all the required info is available from vex2difx at band construction/mapping stage to do that,
+ * However, not all of the required infos are available to vex2difx at the band construction/mapping stage,
  * hence we have to include all antennas in this check even if some antennas might be 'droppped' later on.
  */
 bool AutoBands::covered(double f0, double f1) const
@@ -1005,9 +1096,21 @@ std::ostream& operator << (std::ostream& os, const AutoBands& x)
 
 std::ostream& operator << (std::ostream& os, const AutoBands::Band& x)
 {
-	os << std::fixed
-		<< "start at " << std::setw(15) << std::setprecision(8) << (x.flow*1e-6) << " MHz with bw "
-		<< std::setw(11) << std::setprecision(7) << (x.bandwidth()*1e-6) << " MHz";
+	if (x.overlapping)
+	{
+		os << std::fixed
+			<< "overlapped " << std::setw(15) << std::setprecision(8) << x.min_flow*1e-6 << "--" << x.max_fhigh*1e-6 << " MHz bw "
+			<< std::setw(11) << std::setprecision(7) << ((x.max_fhigh-x.min_flow)*1e-6) << " MHz "
+			<< " unique " << std::setw(15) << std::setprecision(8) << x.flow*1e-6 << "--" << x.fhigh*1e-6 << " MHz with bw "
+			<< std::setw(11) << std::setprecision(7) << (x.bandwidth()*1e-6) << " MHz";
+	}
+	else
+	{
+		os << std::fixed
+			<< "start at " << std::setw(15) << std::setprecision(8) << (x.flow*1e-6) << " MHz with bw "
+			<< std::setw(11) << std::setprecision(7) << (x.bandwidth()*1e-6) << " MHz";
+	}
+
 	return os;
 }
 

--- a/applications/vex2difx/src/autobands.h
+++ b/applications/vex2difx/src/autobands.h
@@ -35,7 +35,7 @@ class freq;
 class AutoBands
 {
 public:
-	AutoBands() : outputbandwidth(-1), permitgaps(false), verbosity(0) { }
+	AutoBands();
 	AutoBands(double outputbandwidth_Hz, int verbosity=0, bool permitgaps=false);
 	~AutoBands();
 
@@ -45,12 +45,19 @@ public:
 	/// this can be a recorded band or a zoom band or just a virtual band.
 	class Band {
 	public:
-		double flow;		///< Start frequency of the spectral region in Hz
-		double fhigh;		///< Stop frequency of the spectral in Hz
+		double flow;		///< Start frequency of the spectral region in Hz, without overlaps
+		double fhigh;		///< Stop frequency of the spectral region in Hz
 		int antenna;		///< Arbitrary but unique antenna identifier
 
+		bool overlapping;	///< True if band overlaps with neighbour(s)
+		double min_flow;	///< Start frequency of the spectral region in Hz, with overlap retained
+		double max_fhigh;	///< Stop frequency of the spectral region in Hz
+
 		Band(double flow_, double fhigh_, int antenna_)
-			: flow(flow_),fhigh(fhigh_),antenna(antenna_) { }
+			: flow(flow_),fhigh(fhigh_),antenna(antenna_),overlapping(false),min_flow(flow_),max_fhigh(fhigh_) { }
+
+		Band(double flow_, double fhigh_, double flow_min_, double fhigh_max_, int antenna_)
+			: flow(flow_),fhigh(fhigh_),antenna(antenna_),overlapping(true),min_flow(flow_min_),max_fhigh(fhigh_max_) { }
 
 		double bandwidth() const;
 		bool operator==(const freq& rhs) const;
@@ -145,7 +152,10 @@ public:
 	void addRecbands(const std::vector<freq>& freqs, int antId = -1);
 
 	/// Return the greatest-common-divisor of a list of frequencies
-	double getGranularity(const std::vector<double>& freqs) const;
+	double computeGranularity(const std::vector<double>& freqs) const;
+
+	/// Set bandwidth granularity [Hz] to use if possbile when generating auto-zooms that form outputbands
+	double setAutozoomGranularity(const double& azgranularity_Hz);
 
 	/// Automatically build a set of outputbands and their constituent bands,
 	/// based upon previously registered (cf. addRecbands()) recorded bands.
@@ -178,6 +188,7 @@ public:
 	double minrecfreq, maxrecfreq;
 	unsigned int Nant;
 	double outputbandwidth;
+	double autozoomgranularity;
 	bool permitgaps;
 
 private:


### PR DESCRIPTION

The outputband auto-zoom planning logic (in autobands.cpp) places "frequency breaks" at the upper and lower edge of every recorded band found in the VEX file. Such breaks demark hard boundaries for the potential automatic zoom bands.

Handling of overlapped recorded bands is tricky esp. with observations with Phased ALMA.

User-requested OutputBands that reside entirely within a single ALMA recorded band, yet extend into the overlap portion(s) of that recorded band, will be chopped up into 2-3 zoom bands. The zooms at the low/high ends can be ridiculously small, e.g., only 0.140625 MHz or 1.656250 MHz wide. Edges of these zooms are flagged in .channelflags. 

Preference from some PIs and the EHT VLBI calibration folks was to avoid these "unnecessary" zooms and the flagged channels associated with them.

This PR firstly adds overlap detection to the AutoBand logic and extends internal bookeeping.

Secondly, to get rid of small zooms, overlapped regions that used to produce two frequency breaks (start and stop of the overlapped region) are now replaced in the bookkeeping by a single frequency break (mid-point of the overlapped region). This method stops AutoBands from introducing "unnecessary" zooms in EHT VLBI.

This simple solution works well enough for EHT VLBI.

In a future revision this replacement via a static mid-point frequency break could be made more flexible, but, that needs more code.

Would be nice to have the current simpler solution be integrated into soon to be released 2.9.0/2.9.1.

