### PR TITLE
Fxi TypeError when IPP path not found and handle possibilities>1

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The official repo for DiFX.
 
 DiFX requires MPI, PGPLOT and IPP.
 
-Details see https://github.com/difx/difx/wiki/Installation
+Details see https://github.com/difx/difx/wiki/difx-installation
 
 ### For DiFX Users
 

--- a/genipppc
+++ b/genipppc
@@ -24,7 +24,7 @@ def usage(prog):
 def getippversion(path):
     if islink(path):
         path = join(dirname(path), readlink(path))
-# First try ippversion.h
+    # First try ippversion.h
     ippheader = path+'/include/ippversion.h'
     if not isfile(ippheader):
         ippheader = path+'/ipp/include/ippversion.h'
@@ -50,16 +50,15 @@ def getippversion(path):
         s = path.split('/')
         possibilities = []
         for part in s:
-            t = path.split('.')
+            t = part.split('.')
             if len(t) > 1:
                 possibilities.append(part)
-                if len(possibilities) < 1:
-                    print('Sorry, cannot determine ipp version from path')
-                    exit(0)
-                    if len(possibilities) > 1:
-                        print('Guessing version == %s' % possibilities[-1])
-
-                        return (path, possibilities[-1])
+        if len(possibilities) < 1:
+            print('Sorry, cannot determine ipp version from path')
+            return (path, 'unknown')
+        if len(possibilities) > 1:
+            print('Guessing version == %s' % possibilities[-1])
+        return (path, possibilities[-1])
                     
     else:
         print("Reading version from ", ippheader)
@@ -77,7 +76,7 @@ def getippversion(path):
             print("Have version ", major.group(1) + "." + minor.group(1))
             return (path, major.group(1) + "." + minor.group(1))
         print("Sorry, cannot find IPP_VERSION_STR in ", ippheader)
-        exit(0)
+        return (path, 'unknown')
     
 # fixme: possibly should use uname to get this information
 def getarch():


### PR DESCRIPTION
Hi @walterfb , this patch addresses two issues:
1. Resolves TypeError that occurred when the IPP path couldn't be located;
2. Corrects logic handling for cases where possibilities exceed 1

I wish to merge this to `dev` and `2.9.0-a` branch after your review and approve.
