### PR TITLE
Enhance ANTAB by documenting the Tsys columns

### DIFF
--- a/applications/polconvert/src/task_polconvert.py
+++ b/applications/polconvert/src/task_polconvert.py
@@ -2072,6 +2072,11 @@ calibrated phased arrays (i.e., phased ALMA).
      print("INDEX= "+', '.join(
         ['\'L%i|R%i\''%(i+1,i+1) for i in range(len(doIF))]), file=outf)
      print("/", file=outf)
+     for colnr in range(len(doIF)):
+       di = doIF[colnr] - 1
+       fmid = FrInfo['FREQ (MHZ)'][di] + (FrInfo['BW (MHZ)'][di]/2 if FrInfo['SIDEBAND'][di][0]=='U' else -FrInfo['BW (MHZ)'][di]/2)
+       v = (colnr+1, colnr+1, colnr+1, di, FrInfo['FREQ (MHZ)'][di], FrInfo['SIDEBAND'][di], FrInfo['BW (MHZ)'][di], fmid)
+       print("! Column %d = L%i|R%i : DiFX freq %d, %.5f MHz %sSB bw %.2f MHz, center %.5f MHz" % v, file=outf)
      fmt0 = "%i %i:%2.4f  "
      # boost field width to retain significant figures
      fmt1 = "%10.4f  "*len(doIF)


### PR DESCRIPTION

As a copy of 
[…https://github.com/marti-vidal-i/PolConvert/pull/15](https://github.com/marti-vidal-i/PolConvert/pull/15)

Project PIs often were uncertain about which FITS IF (sky frequency) each Tsys column actually corresponds to. There was occasionally some confusion due to potential re-sorting of frequency entries during difx2fits conversion and or FITS import into AIPS/CASA.

This pull request adds comments into the generated ANTAB that document what column corresponds to which sky frequency.

Example:

```
GAIN AA  ELEV DPFU=0.031   FREQ=10,100000
POLY=1.0000E+00
/
TSYS AA  FT=1.0  TIMEOFF=0
INDEX= 'L1|R1', 'L2|R2', 'L3|R3', 'L4|R4', 'L5|R5', 'L6|R6', 'L7|R7', 'L8|R8', 'L9|R9', 'L10|R10', 'L11|R11', 'L12|R12', 'L13|R13', 'L14|R14', 'L15|R15', 'L16
/
! Column 1 = L1|R1 : DiFX freq 66, 228162.79688 MHz USB bw 58.00 MHz, center 228191.79688 MHz
! Column 2 = L2|R2 : DiFX freq 67, 228221.39062 MHz USB bw 58.00 MHz, center 228250.39062 MHz
! Column 3 = L3|R3 : DiFX freq 68, 228279.98438 MHz USB bw 58.00 MHz, center 228308.98438 MHz
! Column 4 = L4|R4 : DiFX freq 69, 228338.57812 MHz USB bw 58.00 MHz, center 228367.57812 MHz
! Column 5 = L5|R5 : DiFX freq 70, 228397.17188 MHz USB bw 58.00 MHz, center 228426.17188 MHz
! Column 6 = L6|R6 : DiFX freq 71, 228455.76562 MHz USB bw 58.00 MHz, center 228484.76562 MHz
! Column 7 = L7|R7 : DiFX freq 72, 228514.35938 MHz USB bw 58.00 MHz, center 228543.35938 MHz
! Column 8 = L8|R8 : DiFX freq 73, 228572.95312 MHz USB bw 58.00 MHz, center 228601.95312 MHz
! Column 9 = L9|R9 : DiFX freq 74, 228631.54688 MHz USB bw 58.00 MHz, center 228660.54688 MHz
! Column 10 = L10|R10 : DiFX freq 75, 228690.14062 MHz USB bw 58.00 MHz, center 228719.14062 MHz
! Column 11 = L11|R11 : DiFX freq 76, 228748.73438 MHz USB bw 58.00 MHz, center 228777.73438 MHz
! Column 12 = L12|R12 : DiFX freq 77, 228807.32812 MHz USB bw 58.00 MHz, center 228836.32812 MHz
! Column 13 = L13|R13 : DiFX freq 78, 228865.92188 MHz USB bw 58.00 MHz, center 228894.92188 MHz
! Column 14 = L14|R14 : DiFX freq 79, 228924.51562 MHz USB bw 58.00 MHz, center 228953.51562 MHz
! Column 15 = L15|R15 : DiFX freq 80, 228983.10938 MHz USB bw 58.00 MHz, center 229012.10938 MHz
! Column 16 = L16|R16 : DiFX freq 81, 229041.70312 MHz USB bw 58.00 MHz, center 229070.70312 MHz
! Column 17 = L17|R17 : DiFX freq 82, 229100.29688 MHz USB bw 58.00 MHz, center 229129.29688 MHz
! Column 18 = L18|R18 : DiFX freq 83, 229158.89062 MHz USB bw 58.00 MHz, center 229187.89062 MHz
! Column 19 = L19|R19 : DiFX freq 84, 229217.48438 MHz USB bw 58.00 MHz, center 229246.48438 MHz
! Column 20 = L20|R20 : DiFX freq 85, 229276.07812 MHz USB bw 58.00 MHz, center 229305.07812 MHz
! Column 21 = L21|R21 : DiFX freq 86, 229334.67188 MHz USB bw 58.00 MHz, center 229363.67188 MHz
! Column 22 = L22|R22 : DiFX freq 87, 229393.26562 MHz USB bw 58.00 MHz, center 229422.26562 MHz
! Column 23 = L23|R23 : DiFX freq 88, 229451.85938 MHz USB bw 58.00 MHz, center 229480.85938 MHz
! Column 24 = L24|R24 : DiFX freq 89, 229510.45312 MHz USB bw 58.00 MHz, center 229539.45312 MHz
! Column 25 = L25|R25 : DiFX freq 90, 229569.04688 MHz USB bw 58.00 MHz, center 229598.04688 MHz
! Column 26 = L26|R26 : DiFX freq 91, 229627.64062 MHz USB bw 58.00 MHz, center 229656.64062 MHz
! Column 27 = L27|R27 : DiFX freq 92, 229686.23438 MHz USB bw 58.00 MHz, center 229715.23438 MHz
! Column 28 = L28|R28 : DiFX freq 93, 229744.82812 MHz USB bw 58.00 MHz, center 229773.82812 MHz
! Column 29 = L29|R29 : DiFX freq 94, 229803.42188 MHz USB bw 58.00 MHz, center 229832.42188 MHz
! Column 30 = L30|R30 : DiFX freq 95, 229862.01562 MHz USB bw 58.00 MHz, center 229891.01562 MHz
! Column 31 = L31|R31 : DiFX freq 96, 229920.60938 MHz USB bw 58.00 MHz, center 229949.60938 MHz
! Column 32 = L32|R32 : DiFX freq 97, 229979.20312 MHz USB bw 58.00 MHz, center 230008.20312 MHz
108 3:41.0040      3.0455      3.0206      3.0354      3.0549      3.0454      3.0994      3.1451      3.1923 ...
108 3:41.0098      3.0483      3.0234      3.0384      3.0580      3.0482      3.1024      3.1482      3.1956 ...
108 3:41.0170      3.0512      3.0263      3.0414      3.0611      3.0510      3.1053      3.1513      3.1989 ...
108 3:41.0227      2.9871      2.9622      2.9757      2.9933      2.9886      3.0394      3.0825      3.1270 ...
108 3:41.0299      2.9254      2.9004      2.9122      2.9275      2.9288      2.9759      3.0159      3.0571 ...
108 3:41.0371      2.8773      2.8521      2.8624      2.8756      2.8824      2.9262      2.9635      3.0018 ...
108 3:41.0429      2.8420      2.8167      2.8256      2.8370      2.8490      2.8898      2.9246      2.9604 ...
...
```


