### PR TITLE
Add DOI badge and citation link for DiFX software

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # DiFX
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.16949346.svg)](https://doi.org/10.5281/zenodo.16949346)
 
 The official repo for DiFX.
 
@@ -90,7 +91,7 @@ This project exists thanks to all the people who contribute.
 
 ## Citation
 
-If you use DiFX in your research, please consider citing our following papers:
+If you use DiFX in your research, please consider citing it via DOI [10.5281/zenodo.16949346](https://doi.org/10.5281/zenodo.16949346) and our following papers:
 
 1. DiFX-2: Deller, A. T., W. F. Brisken, C. J. Phillips, John Morgan, W. Alef, R. Cappallo, E. Middelberg et al. "DiFX-2: a more flexible, efficient, robust, and powerful software correlator." Publications of the Astronomical Society of the Pacific 123, no. 901 (2011): 275.
 


### PR DESCRIPTION
Added a persistent DOI badge and citation section to the DiFX software repository, ensuring the badge is visually prominent and links directly to the official DOI for release versions of DiFX.


## Types of changes

<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [x] Make sure you have already read the [contribution guidelines](../CONTRIBUTION.md) 
- [ ] Bug fix 
- [ ] New feature 
- [x] Documentation change (documentation changes only)
- [ ] Version change


Documentation change checklist:

- [x] If this is a significant change to the readme or other docs, I have checked that they are rendered properly on ReadTheDocs. 