### PR TITLE
EHT VLBI packaging scripts: new FMIX data target

### DIFF
--- a/sites/Haystack/ehtc/ehtc-tarballs.sh
+++ b/sites/Haystack/ehtc/ehtc-tarballs.sh
@@ -19,13 +19,14 @@ The main options are (with defaults in parentheses)
 
 and one of the simple tar targets,
 
-    tar=dxin|swin|fits|hops|hmix|haxp|pcin|pcqk|4fit
+    tar=dxin|swin|fits|hops|hmix|fmix|haxp|pcin|pcqk|4fit
 
 which specify which tarballs are to be made:
 
     dxin    DiFX input files
     swin    DiFX (SWIN) output files
     fits    difx2fits outputs
+    fmix    difx2fits outputs prior to polconvert (mixed pols, but relabeled)
     hops    difx2mark4 outputs following polconvert
     hmix    difx2mark4 outputs prior to polconvert (mixed pols)
     haxp    difx2mark4 outputs alma-only mixed pols 
@@ -35,10 +36,10 @@ which specify which tarballs are to be made:
 
 Or, for convenience,
 
-    tar=post-corr   does:   dxin swin haxp
+    tar=post-corr   does:   dxin swin haxp fmix
     tar=no-alma     does:   dxin swin fits hops
     tar=no-hops     does:   dxin swin fits
-    tar=pre-alma    does:   dxin swin hmix
+    tar=pre-alma    does:   dxin swin hmix fmix
     tar=post-alma   does:   pcin fits hops pcqk
 
 Note 4fit probably doesn't make sense in these groupings: The 4fit
@@ -409,6 +410,19 @@ fits)
     $d2ft || [ -d $fits ] || { echo no FITS output dir $fits; exit 3; }
     $d2ft && work=fits
     ;;
+fmix)
+    fits=${exp}-${relv}-$subv-$label-mixedpol.fits
+    FITS=${exp}-${relv}-$subv-$label-mixedpol
+    $verb && echo making FITS in `pwd`/$fits
+    $dry || dotar=true
+    tarname=${exp}-${relv}-$subv-$label-fmix.tar
+    $nuke && rm -rf $fits
+    $nuke && rm -f $workdir/$tarname && rm -f $destdir/$tarname &&
+             rm -f $workdir/logs/$tarname.log
+    content="$fits"
+    $d2ft || [ -d $fits ] || { echo no FITS output dir $fits; exit 3; }
+    $d2ft && work=fits
+    ;;
 hops|hmix|haxp)
     $verb && [ $tar = hops ] && echo making HOPS'(post-pc)'   in `pwd`/$expn
     $verb && [ $tar = hmix ] && echo making HOPS'(pre-pc)'    in `pwd`/$expn
@@ -515,6 +529,9 @@ post-corr)
     cd $workdir
     $0 tar=haxp $com1 $com2 $com3 $com4 $com5 $com6 || {
         echo swin failed ; exit 3; }
+    cd $workdir
+    $0 tar=fmix $com1 $com2 $com3 $com4 $com5 $com6 || {
+        echo fmix failed ; exit 3; }
     exit 0
     ;;
 pre-alma)
@@ -528,6 +545,9 @@ pre-alma)
     cd $workdir
     $0 tar=hmix $com1 $com2 $com3 $com4 $com5 $com6 || {
         echo hmix failed ; exit 3; }
+    cd $workdir
+    $0 tar=fmix $com1 $com2 $com3 $com4 $com5 $com6 || {
+        echo fmix failed ; exit 3; }
     exit 0
     ;;
 post-alma)
@@ -550,6 +570,7 @@ post-alma)
     dxin    DiFX input files
     swin    DiFX (SWIN) output files
     fits    difx2fits outputs
+    fmix    difx2fits outputs prior to polconvert (mixed pols, but relabeled)
     hops    difx2mark4 outputs
     hmix    difx2mark4 outputs prior to polconvert (mixed pols)
     haxp    difx2mark4 outputs alma-only mixed pols 
@@ -557,10 +578,10 @@ post-alma)
     pcqk    polconvert quick-look outputs (if ALMA)
     4fit    correlator fourfit output (pc'd; type 200s + alist)
 
-    tar=post-corr   does:   dxin swin haxp
+    tar=post-corr   does:   dxin swin haxp fmix
     tar=no-alma     does:   dxin swin fits hops
     tar=no-hops     does:   dxin swin fits
-    tar=pre-alma    does:   dxin swin hmix
+    tar=pre-alma    does:   dxin swin hmix fmix
     tar=post-alma   does:   pcin fits hops pcqk
 ....EOF
     exit 3
@@ -584,7 +605,7 @@ pcin)
     ls -l SourceList-$label.txt SideBand-$label.txt Jobs-$label.txt
     delete="SourceList-$label.txt SideBand-$label.txt Jobs-$label.txt"
     ;;
-fits)
+fits|fmix)
     # the problem here is that the directory needs to be named .fits
     # to correspond to the other packages, but that name is also used
     # for the FITS file generated in this directory.
@@ -599,8 +620,9 @@ fits)
     }
     parts="{log,xcb,wts,cpol,apd,apc,acb,jobmatrix,fits,fits_setup*}"
     $dry && {
+        echo cd `pwd`
         echo mkdir $FITS.work
-        echo $d2ftexec -v $ov $jobs $fitsout \> $fog
+        echo $d2ftexec -v $ov --relabelCircular $jobs $fitsout \> $fog
         $fitsname || echo mv $EXP* $FITS.work
         $fitsname && echo mv $FITS*$parts $FITS.work
         echo mv $FITS.work $FITS.fits
@@ -609,9 +631,10 @@ fits)
         $save && savename=$fits.save
         $verb && echo follow difx2fits with: &&
             echo '  'tail -n +1 -f `pwd`/$fog
-        echo $d2ftexec -v $ov $jobs $fitsout > $fog
+        echo cd `pwd` >> $fog
+        echo $d2ftexec -v $ov --relabelCircular $jobs $fitsout > $fog
         echo =================== >> $fog
-        $d2ftexec -v $ov $jobs $fitsout >> $fog 2>&1 || {
+        $d2ftexec -v $ov --relabelCircular $jobs $fitsout >> $fog 2>&1 || {
             echo difx2fits failed; exit 4; }
         # generate fits packaging summary with pcList.pl
         pclist=`type -p pcList.pl`

--- a/sites/Haystack/ehtc/ehtc-tarballs.sh
+++ b/sites/Haystack/ehtc/ehtc-tarballs.sh
@@ -26,7 +26,7 @@ which specify which tarballs are to be made:
     dxin    DiFX input files
     swin    DiFX (SWIN) output files
     fits    difx2fits outputs
-    fmix    difx2fits outputs prior to polconvert (mixed pols, but relabeled)
+    fmix    difx2fits outputs prior to polconvert (mixed pols, just relabeled X,Y -> R,L)
     hops    difx2mark4 outputs following polconvert
     hmix    difx2mark4 outputs prior to polconvert (mixed pols)
     haxp    difx2mark4 outputs alma-only mixed pols 
@@ -570,7 +570,7 @@ post-alma)
     dxin    DiFX input files
     swin    DiFX (SWIN) output files
     fits    difx2fits outputs
-    fmix    difx2fits outputs prior to polconvert (mixed pols, but relabeled)
+    fmix    difx2fits outputs prior to polconvert (mixed pols, just relabeled X,Y -> R,L)
     hops    difx2mark4 outputs
     hmix    difx2mark4 outputs prior to polconvert (mixed pols)
     haxp    difx2mark4 outputs alma-only mixed pols 

--- a/sites/Haystack/ehtc/ehtc-tarballs.sh
+++ b/sites/Haystack/ehtc/ehtc-tarballs.sh
@@ -380,7 +380,7 @@ dxin)
     content2=''
     for j in $jobs
     do
-      content2="$content2 ${j}.{input,calc,errs,flag,im}"
+      content2="$content2 ${j}.{input,calc,errs,flag,channelflags,im}"
       content2="$content2 ${j}.{machines,threads,difxlog}"
     done
     content=$content1$content2
@@ -448,7 +448,7 @@ pcin)
     content2=''
     for j in $jobs
     do
-      content2=" ${j}.{input,calc,flag,im}"
+      content2=" ${j}.{input,calc,flag,channelflags,im}"
     done
     content3=" ${exp}*.codes ${exp}*.conf ${exp}*.vex.obs"
     content=$content1$content2$content3


### PR DESCRIPTION

The range of formal data products from the EHT L1 process is going to be expanded.

In addition to the post-PolConvert FITS-IDI files (which rely on ALMA APP QA2), the EHT L1 data products are going to also include "mixed polarization" FITS-IDI produced from the original, non-polconverted DiFX output data. These are useful for PIs who use new analysis and imaging methods, such as Comrade, which are independent of PolConvert.

It's not yet settled in what form to package and provide these new mixed pol FITS-IDI products.

This Pull Request is a first step towards the goal. Sort of a "request for comments".

Changes in this PR are limited to the scripts under `sites/Haystack/ehtc/`. The PR adds the new data product FMIX (FITS mixed pol) which is the FITS counterpart of the already existing HMIX data product (Mk4/HOPS mixed pol) 

```
    dxin    DiFX input files
    swin    DiFX (SWIN) output files
    fits    difx2fits outputs
    fmix    difx2fits outputs prior to polconvert (mixed pols, relabeled X->"RCP" Y->"LCP") - ** NEW, added by this PR **
    hops    difx2mark4 outputs following polconvert
    hmix    difx2mark4 outputs prior to polconvert (mixed pols)
    haxp    difx2mark4 outputs alma-only mixed pols 
```

The FITS-IDI specifications do not support mixed polarization data labels. Thus the PR uses the `difx2fits --relabelCircular` option - ALMA X gets relabeled as RCP,  Y as LCP).

Project based packaging of DiFX output for, e.g., project 3C84 target J0510+1800, produces these deliverables:

```
-rw-r--r--  1 oper evlbi 9.7M Oct 27 16:08 e22c20-3-b4-3c84-J0510+1800-dxin.tar
-rw-r--r--  1 oper evlbi  15G Oct 27 16:02 e22c20-3-b4-3c84-J0510+1800-fits.tar
-rw-r--r--  1 oper evlbi  15G Oct 27 16:24 e22c20-3-b4-3c84-J0510+1800-fmix.tar   # new
-rw-r--r--  1 oper evlbi 4.0G Oct 27 16:13 e22c20-3-b4-3c84-J0510+1800-haxp.tar
-rw-r--r--  1 oper evlbi  16G Oct 27 16:08 e22c20-3-b4-3c84-J0510+1800-hops.tar
-rw-r--r--  1 oper evlbi 1.1M Oct 27 15:50 e22c20-3-b4-3c84-J0510+1800-pcin.tar
-rw-r--r--  1 oper evlbi  23M Oct 27 16:08 e22c20-3-b4-3c84-J0510+1800-pcqk.tar
-rw-r--r--  1 oper evlbi  16G Oct 27 16:09 e22c20-3-b4-3c84-J0510+1800-swin.tar
```
For reference, the content of the new *-fmix.tar is

```
$ tar tvf e22c20-3-b4-3c84-J0510+1800-fmix.tar
drwxrws--- oper/oper         0 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/
-rw-rw---- oper/oper      5058 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/difx2fits-e22c20-3-b4.log
-rw-rw---- oper/oper     12971 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/e22c20-3-b4-fits.pclist
-rw-rw---- oper/oper   7333058 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.acb
-rw-rw---- oper/oper   2871077 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.apc
-rw-rw---- oper/oper   3348557 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.apd
-rw-rw---- oper/oper      1632 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.channels
-rw-rw---- oper/oper    554317 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.cpol
-rw-rw---- oper/oper 15665904000 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.FITS
-rw-rw---- oper/oper       15976 2025-10-27 16:13 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.log
-rw-rw---- oper/oper       26542 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000_setup1.jobmatrix
-rw-rw---- oper/oper      541443 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.wts
-rw-rw---- oper/oper    35887542 2025-10-27 16:24 e22c20-3-b4-3c84-J0510+1800-mixedpol.fits/E22C20.0.bin0000.source0000.xcb
```

The existing FITS target data product *-fits.tar has content as before of:

```
$ tar tvf e22c20-3-b4-3c84-J0510+1800-fits.tar
drwxr-sr-x oper/evlbi        0 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/
-rw-r--r-- oper/evlbi     5280 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/difx2fits-e22c20-3-b4.log
-rw-r--r-- oper/evlbi     1130 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/e22c20-3-b4-fits.pclist
-rw-r--r-- oper/evlbi  7333058 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.acb
-rw-r--r-- oper/evlbi  2871077 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.apc
-rw-r--r-- oper/evlbi  3348557 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.apd
-rw-r--r-- oper/evlbi     1632 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.channels
-rw-r--r-- oper/evlbi   554317 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.cpol
-rw-r--r-- oper/evlbi 15665535360 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.FITS
-rw-r--r-- oper/evlbi       16730 2025-10-27 15:50 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.log
-rw-r--r-- oper/evlbi       26542 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000_setup1.jobmatrix
-rw-r--r-- oper/evlbi      541443 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.wts
-rw-r--r-- oper/evlbi    35887542 2025-10-27 16:01 e22c20-3-b4-3c84-J0510+1800.fits/E22C20.0.bin0000.source0000.xcb
```


