### PR TITLE
Update README with clearer checkout instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,20 @@ Details see https://github.com/difx/difx/wiki/Installation
 
 At the time of writing, the current stable version of DiFX is DiFX-2.9.0. You can look the DiFX tags for more version.
 
-Then we recommend the user to check out stable version right now. If you want to check out v2.9.0, just type :
+Then we recommend the user to check out stable version right now. If you want to make a fresh check out of v2.9.0, just type :
 
 ```bash
 $ git clone https://github.com/difx/difx
 ```
 
-as the main branch is on version 2.9
+as the main branch is on version 2.9.
+
+To update if you had previously cloned the DiFX repository prior to the release of DiFX-2.9.0, update your local repository with git pull and then change to the main branch if necessary:
+
+```bash
+$ git pull
+$ git checkout main
+```
 
 ### For DiFX Developers
 


### PR DESCRIPTION
Clarify instructions for updating to the latest stable version from a previous checkout, because I have been in contact with a user that I think hasn't been updating their installation because of confusion over how to use git properly. Should we also make it clear how to keep a previous version of setup.bash?