### PR TITLE
Bugfix complex

### DIFF
--- a/libraries/mark5access/mark5access/mark5_stream_unpacker.c
+++ b/libraries/mark5access/mark5access/mark5_stream_unpacker.c
@@ -176,7 +176,15 @@ int mark5_unpack_complex_with_offset(struct mark5_stream *ms, const void *packed
 	/* set readposition to first desired sample */
 	ms->readposition = (offsetsamples % ms->framesamples)*ms->nchan*ms->nbit*2*ms->decimation/8;
 
-	ms->blanker(ms);
+	/* Do NOT call ms->blanker(ms) here: mark5_stream_next_frame() above has
+	 * already run either the blanker (frame validated good) or
+	 * mark5_stream_blank_frame() (validation failed, e.g. invalid bit set or
+	 * zero Data Frame Length).  An extra blanker call would overwrite the
+	 * whole-frame blanking of an invalid start frame with "all valid"
+	 * whenever the payload lacks fill pattern, so such frames (e.g. the
+	 * zeroed region past the end of a recording) would be decoded and
+	 * correlated as good data at full weight.  The real-sampled
+	 * mark5_unpack_with_offset() has no such call. */
 
 	return ms->complex_decode(ms, nsamp, unpacked);
 }

--- a/libraries/vdifio/utils/generateVDIF.c
+++ b/libraries/vdifio/utils/generateVDIF.c
@@ -438,8 +438,18 @@ int main (int argc, char * const argv[]) {
 
    IPPMALLOC(scratchHilbert, 32fc, frameperbuf*samplesperframe);
    status = ippsHilbertGetSize_32f32fc(frameperbuf*samplesperframe, ippAlgHintNone, &sizeSpec, &sizeBuf);
+   if (status != ippStsNoErr) {
+     fprintf(stderr, "Error calling ippsHilbertGetSize for %d points (%s) (Line %d)\n",
+	     frameperbuf*samplesperframe, ippGetStatusString(status), __LINE__ -3);
+     exit(1);
+   }
 
    hSpec = (IppsHilbertSpec*)ippMalloc(sizeSpec);
+   if (hSpec==NULL) {
+     fprintf(stderr, "Error allocating %d bytes for Hilbert spec (%d point transform) at line %d\n",
+	     sizeSpec, frameperbuf*samplesperframe, __LINE__ -3);
+     exit(EXIT_FAILURE);
+   }
    IPPMALLOC(hBuffer, 8u, sizeBuf);
    status = ippsHilbertInit_32f32fc(frameperbuf*samplesperframe, ippAlgHintNone, hSpec, hBuffer);
     if (status != ippStsNoErr) {

--- a/mpifxcorr/ChangeLog
+++ b/mpifxcorr/ChangeLog
@@ -1,3 +1,7 @@
+* Post version 2.9
+* Fixed bug that zeroed complex sampled data inadvertently when samplegranularity > 1
+* Fixed bug that allowed garbage data to be correlated for complex-sampled data for the last integration of a scan (one or two FFTs worth)
+
 Version 2.9
 ~~~~~~~~~~~
 * Fix missing/broken autocorrelation, e.g. when bands matched but differed in PCal spacing (ported to DiFX 2.8)

--- a/mpifxcorr/src/mk5mode.cpp
+++ b/mpifxcorr/src/mk5mode.cpp
@@ -121,9 +121,25 @@ float Mk5Mode::unpack(int sampleoffset, int subloopindex)
     int erasedsamples = 0;
 
     mungedoffset = sampleoffset % mark5stream->samplegranularity;
+    // For complex data the erasure must be done in complex-sample units:
+    // unpackedcomplexarrays is a cast of the same memory, so indexing the
+    // float array with these (complex-sample) bounds zeroes float elements
+    // [unpacksamples+mungedoffset, samplestounpack) - i.e. the re/im of the
+    // complex sample at the MIDDLE of the FFT window (fftchannels/2) - rather
+    // than the intended beyond-window tail. That corrupted one mid-window
+    // sample per FFT for every granularity>1 complex config, while leaving
+    // the returned weight exactly 1.0 (the two erased floats were counted as
+    // two samples, cancelling the extra ones mark5access had reported).
     for(int i = 0; i < mungedoffset; i++) {
       for(int b = 0; b < mark5stream->nchan; ++b) {
-        if(unpackedarrays[b][i] != 0.0) {
+        if(usecomplex) {
+          if(unpackedcomplexarrays[b][i].re != 0.0f || unpackedcomplexarrays[b][i].im != 0.0f) {
+            unpackedcomplexarrays[b][i].re = 0.0f;
+            unpackedcomplexarrays[b][i].im = 0.0f;
+            erasedsamples++;
+          }
+        }
+        else if(unpackedarrays[b][i] != 0.0) {
           unpackedarrays[b][i] = 0.0;
           erasedsamples++;
         }
@@ -131,7 +147,14 @@ float Mk5Mode::unpack(int sampleoffset, int subloopindex)
     }
     for(int i = unpacksamples + mungedoffset; i < samplestounpack; i++) {
       for(int b = 0; b < mark5stream->nchan; ++b) {
-        if(unpackedarrays[b][i] != 0.0) {
+        if(usecomplex) {
+          if(unpackedcomplexarrays[b][i].re != 0.0f || unpackedcomplexarrays[b][i].im != 0.0f) {
+            unpackedcomplexarrays[b][i].re = 0.0f;
+            unpackedcomplexarrays[b][i].im = 0.0f;
+            erasedsamples++;
+          }
+        }
+        else if(unpackedarrays[b][i] != 0.0) {
           unpackedarrays[b][i] = 0.0;
           erasedsamples++;
         }


### PR DESCRIPTION
two bugfixes for complex sampled data are implemented. A minor bugfix for generateVDIF is also included. The synthetic test suite has been run and passed.

## Description
Some samples were inadvertently blanked for samplegranularity>1 for complex data. This introduced a fraction of a percent level error for complex sampled data (FFT size dependent). Also, invalid data was read past the end of a file for complex data (this only affected the final integration of a scan, but could lead to significant corruption of that last visibility.

## Motivation and Context
These are fixes that have been ported from the GPU branch that affected the CPU code (identified by testing of GPU-CPU, and eventually finding the error was on the CPU code!) The full-blown merge of the GPU code is still some time off, hence this bugfix.


## Types of changes
<!--- What types of changes does your code introduce? Put an replace the space with an `x` in all the boxes that apply: -->
- [ ] Make sure you have already read the [contribution guidelines](../CONTRIBUTION.md) 
- [x] Bug fix 
- [ ] New feature 
- [ ] Documentation change (documentation changes only)
- [ ] Version change


Bug fix checklist:

- [ ] My fix includes a new test that breaks as a result of the bug (if possible).
- [x] All new and existing tests pass in DiFX 2.9.0 
       By this i mean, USB and LSB are unchanged c.f. 2.9.0 in the synthetic tests, complex (USB/LSB/DSB) differ at the percent level as expected due to the bug fix, but match the CPU and GPU implementations from the GPU branch.
- [x] I have updated the documentation.